### PR TITLE
SC-5926: hide messenger options only using css

### DIFF
--- a/views/administration/school.hbs
+++ b/views/administration/school.hbs
@@ -213,67 +213,64 @@
 							</div>
 						{{/ifConfig}}
 
-						{{#ifConfig "FEATURE_MESSENGER_SCHOOL_SETTINGS_VISIBLE" true}}
-							<div class="form-group">
-								<label>
-									<input
-										id="messenger"
-										type="checkbox"
-										name="messenger"
-										value="true"
-										{{#inArray "messenger" ../school.features}}checked{{/inArray}}
-										{{#userHasPermission 'SCHOOL_EDIT'}}{{else}}
-											{{#userHasPermission 'SCHOOL_CHAT_MANAGE'}}{{else}}
-												disabled
-											{{/userHasPermission}}
-										{{/userHasPermission}}
+                        {{! Only hide setting from UI and not completly from the DOM to ensure that the configured state is passed back to the server }}
+                        <div class="form-group {{#ifConfig "FEATURE_MESSENGER_SCHOOL_SETTINGS_VISIBLE" false}}hidden{{/ifConfig}}">
+                            <label>
+                                <input
+                                    id="messenger"
+                                    type="checkbox"
+                                    name="messenger"
+                                    value="true"
+                                    {{#inArray "messenger" ../school.features}}checked{{/inArray}}
+                                    {{#userHasPermission 'SCHOOL_EDIT'}}{{else}}
+                                        {{#userHasPermission 'SCHOOL_CHAT_MANAGE'}}{{else}}
+                                            disabled
+                                        {{/userHasPermission}}
+                                    {{/userHasPermission}}
+                                />
+                                {{$t "administration.school.label.activeChatFunction" }}
+                                <p class="text-muted">
+                                    {{$t "administration.school.text.ifChatsAreActivatedAtYourSchool" }}
+                                </p>
+                            </label>
+                        </div>
+
+                        {{! This elements visibility gets toggled by javascript, to only show it if the messenger is enabled }}
+                        <div id="messenger-sub-options">
+                            {{! Only hide setting from UI and not completly from the DOM to ensure that the configured state is passed back to the server }}
+                            <div class="form-group {{#ifConfig "FEATURE_MESSENGER_SCHOOL_SETTINGS_VISIBLE" false}}hidden{{/ifConfig}} {{#ifConfig "FEATURE_MESSENGER_SCHOOL_ROOM_ENABLED" false}}hidden{{/ifConfig}}">
+                                <label>
+                                    <input
+                                        type="checkbox"
+                                        name="messengerSchoolRoom"
+                                        value="true"
+                                        {{#inArray "messengerSchoolRoom" ../school.features}}checked{{/inArray}}
+                                        {{#userHasPermission 'SCHOOL_EDIT'}}{{else}}
+                                            {{#userHasPermission 'SCHOOL_CHAT_MANAGE'}}{{else}}
+                                                disabled
+                                            {{/userHasPermission}}
+                                        {{/userHasPermission}}
                                     />
-									{{$t "administration.school.label.activeChatFunction" }}
-									<p class="text-muted">
-										{{$t "administration.school.text.ifChatsAreActivatedAtYourSchool" }}
-									</p>
-								</label>
-							</div>
+                                    {{$t "administration.school.label.createChatRoom" }}
+                                    <p class="text-muted">
+                                    {{$t "administration.school.text.chatRoomPermissions" }}
+                                    </p>
+                                </label>
+                            </div>
+                        </div>
 
-							{{#ifConfig "FEATURE_MESSENGER_SCHOOL_ROOM_ENABLED" true}}
-								<div id="messenger-sub-options">
-									<div class="form-group">
-										<label>
-											<input
-												type="checkbox"
-												name="messengerSchoolRoom"
-												value="true"
-												{{#inArray "messengerSchoolRoom" ../school.features}}checked{{/inArray}}
-												{{#userHasPermission 'SCHOOL_EDIT'}}{{else}}
-													{{#userHasPermission 'SCHOOL_CHAT_MANAGE'}}{{else}}
-														disabled
-													{{/userHasPermission}}
-												{{/userHasPermission}}
-											/>
-                                            {{$t "administration.school.label.createChatRoom" }}
-											<p class="text-muted">
-                                            {{$t "administration.school.text.chatRoomPermissions" }}
-											</p>
-										</label>
-									</div>
-								</div>
-							{{/ifConfig}}
-						{{/ifConfig}}
-
-						{{#ifConfig "FEATURE_MESSENGER_SCHOOL_SETTINGS_VISIBLE" false}}
-							{{#if @root.ROCKETCHAT_SERVICE_ENABLED}}
-								<div class="form-group">
-									<label>
-										<input type="checkbox" name="rocketchat" value="true"
-											{{#inArray "rocketChat" ../school.features}}checked{{/inArray}}>
-										{{$t "administration.school.label.activeChatFunction" }}
-										<p class="text-muted">
-											{{$t "administration.school.text.ifChatsAreActivatedAtYourSchoolTeamAdministratorsCan" }}
-										</p>
-									</label>
-								</div>
-							{{/if}}
-						{{/ifConfig}}
+                        {{#if @root.ROCKETCHAT_SERVICE_ENABLED}}
+                            <div class="form-group {{#ifConfig "FEATURE_MESSENGER_SCHOOL_SETTINGS_VISIBLE" true}}hidden{{/ifConfig}}">
+                                <label>
+                                    <input type="checkbox" name="rocketchat" value="true"
+                                        {{#inArray "rocketChat" ../school.features}}checked{{/inArray}}>
+                                    {{$t "administration.school.label.activeChatFunction" }}
+                                    <p class="text-muted">
+                                        {{$t "administration.school.text.ifChatsAreActivatedAtYourSchoolTeamAdministratorsCan" }}
+                                    </p>
+                                </label>
+                            </div>
+                        {{/if}}
 
 						{{#ifConfig "FEATURE_VIDEOCONFERENCE_ENABLED" true}}
 						<div class="form-group">


### PR DESCRIPTION
# Description

Hide messenger options only using css but keep them in the DOM to send the form data back to the server.

<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests

- https://ticketsystem.schul-cloud.org/browse/SC-5926
<!--
Base links to copy
- https://github.com/schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.schul-cloud.org/browse/SC-????
-->

## Changes
- elements are still in the dom and information is send back to the server on submit

## Data Security <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>
- no changes

## Deployment
- -

## New Repos, NPM packages or vendor scripts
- -

## Screenshots of UI changes
- - 

## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
