### PR TITLE
i18n SC-6153 Quickfix invitation modal

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -320,6 +320,9 @@
 			}
 		},
 		"form_InvitationStudent": {
+			"label": {
+				"distributeLinkToInvite": "Um in die HPI Schul-Cloud einzuladen, verteile folgenden Link an:"
+			},
 			"text": {
 				"beforeTheSchoolCloudCanBeUsed": "Bevor die Nutzung der HPI Schul-Cloud möglich ist, müssen Eltern und/oder Schüler den elektronischen Einwilligungsprozess durchlaufen haben.",
 				"studentUnderYears": "<b>Schüler unter {{age}} Jahre: </b> die Eltern <br/> <b>Schüler ab {{age}} Jahre: </b> an die Schüler selbst <br/>"
@@ -622,8 +625,7 @@
 				"importStudents": "Schüler importieren"
 			},
 			"label": {
-				"sendRegistrationLinkToStudent": "Registrierungslink an Schüler:innen senden",
-				"distributeLinkToInvite": "Um in die HPI Schul-Cloud einzuladen, verteile folgenden Link an:"
+				"sendRegistrationLinkToStudent": "Registrierungslink an Schüler:innen senden"
 			},
 			"text": {
 				"allApprovalsAvailable": "Alle Zustimmungen vorhanden",

--- a/locales/de.json
+++ b/locales/de.json
@@ -408,7 +408,6 @@
 				"teachingTeacher": "Unterrichtenderlehrer:in",
 				"termsOfUse": "Nutzungsbedingungen",
 				"timeSpan": "Zeitraum (z.B. Schuljahr)",
-				"toInviteToTheSchoolCloud": "Um in die HPI Schul-Cloud einzuladen, verteile folgenden Link an:",
 				"weekday": "Wochentag"
 			},
 			"placeholder": {
@@ -623,7 +622,8 @@
 				"importStudents": "Schüler importieren"
 			},
 			"label": {
-				"sendRegistrationLinkToStudent": "Registrierungslink an Schüler:innen senden"
+				"sendRegistrationLinkToStudent": "Registrierungslink an Schüler:innen senden",
+				"distributeLinkToInvite": "Um in die HPI Schul-Cloud einzuladen, verteile folgenden Link an:"
 			},
 			"text": {
 				"allApprovalsAvailable": "Alle Zustimmungen vorhanden",

--- a/views/administration/forms/form-invitation-student.hbs
+++ b/views/administration/forms/form-invitation-student.hbs
@@ -1,8 +1,8 @@
 <input name="schoolId" type="hidden" data-force-value="true" value="{{currentSchool}}" />
 <div class="form-group">
-    <label for="invitation-link">{{$t "administration.label.toInviteToTheSchoolCloud" }} </label>
+    <label for="invitation-link">{{$t "administration.students.label.distributeLinkToInvite" }} </label>
     <p>
-        {{{$t "administration.global.text.studentUnderYears" (dict "age" CONSENT_WITHOUT_PARENTS_MIN_AGE_YEARS)}}}
+        {{{$t "administration.form_InvitationStudent.text.studentUnderYears" (dict "age" CONSENT_WITHOUT_PARENTS_MIN_AGE_YEARS)}}}
     </p>
     <p>{{$t "administration.form_InvitationStudent.text.beforeTheSchoolCloudCanBeUsed" }}</p>
     <input id="invitation-link" class="form-control" name="invitation" type="text" />

--- a/views/administration/forms/form-invitation-student.hbs
+++ b/views/administration/forms/form-invitation-student.hbs
@@ -1,6 +1,6 @@
 <input name="schoolId" type="hidden" data-force-value="true" value="{{currentSchool}}" />
 <div class="form-group">
-    <label for="invitation-link">{{$t "administration.students.label.distributeLinkToInvite" }} </label>
+    <label for="invitation-link">{{$t "administration.form_InvitationStudent.label.distributeLinkToInvite" }} </label>
     <p>
         {{{$t "administration.form_InvitationStudent.text.studentUnderYears" (dict "age" CONSENT_WITHOUT_PARENTS_MIN_AGE_YEARS)}}}
     </p>


### PR DESCRIPTION
Ticket: https://ticketsystem.schul-cloud.org/browse/SC-6153

When inviting students there were two wrong keys (headline and below).

**Affected Pages**

- `administration/students/_id/edit`

**Before**
![Before](https://user-images.githubusercontent.com/16440155/90339923-a5820f80-dff4-11ea-8ae9-15a1892fda91.png)

**After**
![After](https://user-images.githubusercontent.com/16440155/90339857-34daf300-dff4-11ea-9270-9bff13e3e182.png)
