### PR TITLE
SC-5927: Only show team messenger notification if the criteria are met

### DIFF
--- a/controllers/teams.js
+++ b/controllers/teams.js
@@ -543,13 +543,9 @@ router.get('/:teamId', async (req, res, next) => {
 			const usersSchoolHasMessengerEnabled = (res.locals.currentSchoolData.features || []).includes('messenger');
 			// Are there members of other schools in the team which have not activated the messenger?
 			// > Filter team schoolIds to only include schools which really have students in the team
-			const filteredSchoolIds = course.schoolIds.filter((school) => {
-				return !!course.userIds.find((user) => user.schoolId === school.id);
-			});
+			const filteredSchoolIds = course.schoolIds.filter((school) => !!course.userIds.find((user) => user.schoolId === school.id));
 			// > Find if at least one participating school hasn't activated the messenger
-			const otherUsersSchoolsHaveNotMessengerEnabled = !!filteredSchoolIds.find((school) => {
-				return !(school.features || []).includes('messenger');
-			});
+			const otherUsersSchoolsHaveNotMessengerEnabled = !!filteredSchoolIds.find((school) => !(school.features || []).includes('messenger'));
 
 			if (!teamsSchoolHasMessengerEnabled && usersSchoolHasMessengerEnabled) {
 				matrixNotification = res.$t('teams._team.text.messengerNotActiveInTeam');

--- a/controllers/teams.js
+++ b/controllers/teams.js
@@ -536,6 +536,7 @@ router.get('/:teamId', async (req, res, next) => {
 		}
 		let notificationMessage;
 		if (Configuration.get('FEATURE_MATRIX_MESSENGER_ENABLED')) {
+			/* eslint-disable max-len */
 			let matrixNotification;
 			// Is messenger feature flag set in the school which created this team?
 			const teamsSchoolHasMessengerEnabled = (course.schoolIds[0].features || []).includes('messenger');
@@ -586,7 +587,6 @@ router.get('/:teamId', async (req, res, next) => {
 		files = files.filter((file) => file);
 
 		files = files.map((file) => {
-
 			// set saveName attribute with escaped quotes
 			file.saveName = file.name.replace(/'/g, "\\'");
 

--- a/controllers/teams.js
+++ b/controllers/teams.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const express = require('express');
 const moment = require('moment');
+const { Configuration } = require('@schul-cloud/commons');
 
 const authHelper = require('../helpers/authentication');
 const recurringEventsHelper = require('../helpers/recurringEvents');
@@ -13,7 +14,7 @@ const logger = require('../helpers/logger');
 
 const {
 	CALENDAR_SERVICE_ENABLED, ROCKETCHAT_SERVICE_ENABLED,
-	ROCKET_CHAT_URI, FEATURE_MATRIX_MESSENGER_ENABLED,
+	ROCKET_CHAT_URI,
 } = require('../config/global');
 
 const router = express.Router();
@@ -500,7 +501,10 @@ router.get('/:teamId', async (req, res, next) => {
 
 		const course = await api(req).get(`/teams/${req.params.teamId}`, {
 			qs: {
-				$populate: ['ltiToolIds'],
+				$populate: [
+					'ltiToolIds',
+					{ path: 'schoolIds' },
+				],
 			},
 		});
 
@@ -530,18 +534,38 @@ router.get('/:teamId', async (req, res, next) => {
 				rocketChatCompleteURL = undefined;
 			}
 		}
-		const instanceUsesMatrixMessenger = FEATURE_MATRIX_MESSENGER_ENABLED;
-		const courseUsesMatrixMessenger = course.features.includes('messenger');
-		const schoolUsesMatrixMessenger = (res.locals.currentSchoolData.features || []).includes('messenger');
-		let matrixNotification;
-		let messenger = false;
-		if (instanceUsesMatrixMessenger && courseUsesMatrixMessenger && !schoolUsesMatrixMessenger) {
-			matrixNotification = res.$t('teams._team.text.messengerNotActivatedSchool');
-			messenger = true;
-		}
-		if (instanceUsesMatrixMessenger && schoolUsesMatrixMessenger && !courseUsesMatrixMessenger) {
-			matrixNotification = res.$t('teams._team.text.messengerNotActivatedCourse');
-			messenger = true;
+		let notificationMessage;
+		if (Configuration.get('FEATURE_MATRIX_MESSENGER_ENABLED')) {
+			let matrixNotification;
+			// Is messenger feature flag set in the school which created this team?
+			const teamsSchoolHasMessengerEnabled = (course.schoolIds[0].features || []).includes('messenger');
+			// Is the messenger in the current users school activated?
+			const usersSchoolHasMessengerEnabled = (res.locals.currentSchoolData.features || []).includes('messenger');
+			// Are there members of other schools in the team which have not activated the messenger?
+			// > Filter team schoolIds to only include schools which really have students in the team
+			const filteredSchoolIds = course.schoolIds.filter((school) => {
+				return !!course.userIds.find((user) => user.schoolId === school.id);
+			});
+			// > Find if at least one participating school hasn't activated the messenger
+			const otherUsersSchoolsHaveNotMessengerEnabled = !!filteredSchoolIds.find((school) => {
+				return !(school.features || []).includes('messenger');
+			});
+
+			if (!teamsSchoolHasMessengerEnabled && usersSchoolHasMessengerEnabled) {
+				matrixNotification = res.$t('teams._team.text.messengerNotActiveInTeam');
+			} else if (teamsSchoolHasMessengerEnabled && !usersSchoolHasMessengerEnabled) {
+				matrixNotification = res.$t('teams._team.text.messengerNotActivatedSchool');
+			} else if (teamsSchoolHasMessengerEnabled && otherUsersSchoolsHaveNotMessengerEnabled) {
+				matrixNotification = res.$t('teams._team.text.messengerNotActivatedCourse');
+			}
+			if (matrixNotification) {
+				notificationMessage = {
+					message: matrixNotification,
+					type: 'info',
+					title: res.$t('teams._team.text.messengerNotActivatedTitle'),
+					iconClass: 'fa fa-info-circle',
+				};
+			}
 		}
 		course.filePermission = mapPermissionRoles(course.filePermission, roles);
 
@@ -709,13 +733,7 @@ router.get('/:teamId', async (req, res, next) => {
 				userId: res.locals.currentUser._id,
 				teamId: req.params.teamId,
 				rocketChatURL: rocketChatCompleteURL,
-				notificationMessenger: {
-					message: matrixNotification,
-					type: 'info',
-					title: 'Hinweis',
-					iconClass: 'fa fa-info-circle',
-				},
-				messenger,
+				notificationMessage,
 			},
 		);
 	} catch (e) {

--- a/locales/de.json
+++ b/locales/de.json
@@ -2811,6 +2811,8 @@
 				"invitationSuccessfullyAccepted": "Teameinladung erfolgreich angenommen.",
 				"messengerNotActivatedCourse": "Nicht alle Teammitglieder können am Teamchat teilnehmen. Chatten wurde an den Schulen mancher Teammitglieder noch nicht durch den Administrator aktiviert.",
 				"messengerNotActivatedSchool": "Dieses schulübergreifende Team beinhaltet einen Teamchat. Du kannst leider nicht darauf zugreifen, da an deiner Schule Chatten noch nicht durch den Administrator aktiviert wurde.",
+				"messengerNotActiveInTeam": "Dieses schulübergreifende Team beinhaltet keinen Teamchat. Im Gegensatz zu deiner Schule ist in der Schule die das Team erstellt hat Chatten noch nicht durch den Administrator aktiviert.",
+				"messengerNotActivatedTitle": "Hinweis",
 				"theseSettingsWillBeAppliedToNewFiles": "Folgende Berechtigungen werden für neu hochgeladene/erstellte Ordner und Dateien innerhalb des Teams aktiv:",
 				"youCanChangeSettingsForSingleFilesLater": "Du kannst die Zugriffsberechtigungen für einzelne Dateien und Ordner jederzeit bearbeiten."
 			}

--- a/views/lib/loggedin.hbs
+++ b/views/lib/loggedin.hbs
@@ -268,17 +268,18 @@
 					</dl>
 					{{#block "page"}}{{/block}}
                 </main>
-						{{#if messenger}}
-						{{>"lib/components/notification"
-							notification=notificationMessenger
-							style="position: sticky;
-							position: -webkit-sticky;
-							bottom: 1rem;
-							margin-right: 1rem;
-							z-index: 1;
-							margin-left: 40%;"
-							}}
-						{{/if}}
+
+                {{#if notificationMessage}}
+                    {{>"lib/components/notification"
+                        notification=notificationMessage
+                        style="position: sticky;
+                        position: -webkit-sticky;
+                        bottom: 1rem;
+                        margin-right: 1rem;
+                        z-index: 1;
+                        margin-left: 40%;"
+                    }}
+                {{/if}}
             </div>
             {{#unless inline}}
                 {{#embed "lib/footer"}}{{/embed}}


### PR DESCRIPTION
# Description

The criteria to show the notification messages in teams have to be based on the school settings of the different users participating in a team. The previous implementation was based on unrelated flags which resulted in notifications even when only users of one school are in a team and the bidirectional chat is disabled.
<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests

- https://ticketsystem.schul-cloud.org/browse/SC-5927
<!--
Base links to copy
- https://github.com/schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.schul-cloud.org/browse/SC-????
-->

## Changes
- fix criteria
- add message why the team has no messenger for users which are used to use the messenger in their schools
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Data Security <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>
- -
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data security team.
-->

## Deployment
- -
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM packages or vendor scripts
- -
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes
<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->
![Screenshot 2020-08-17 at 1 33 48 PM](https://user-images.githubusercontent.com/3898310/90392160-a4052580-e08e-11ea-887c-5c47f8f48082.png)


## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
