### PR TITLE
SC-6552 - quote at end of footer in sc-card is deleted

### DIFF
--- a/views/lib/components/sc-card.hbs
+++ b/views/lib/components/sc-card.hbs
@@ -53,6 +53,6 @@
                     {{> (concat 'lib/sc-card_additionalInfo/' additionalInfoName title=this.title) }}
                 </div>
             {{/if}}
-            <a href="{{url}}" rel="canonical" aria-label="{{{link-text}}}">{{{ stripHTMLTags this.title }}}>{{{link-text}}}</a>
+            <a href="{{url}}" rel="canonical" aria-label="{{{link-text}}}">{{{ stripHTMLTags this.title }}}&gt;{{{link-text}}}</a>
         </div>
     </article>

--- a/views/lib/components/sc-card.hbs
+++ b/views/lib/components/sc-card.hbs
@@ -53,6 +53,6 @@
                     {{> (concat 'lib/sc-card_additionalInfo/' additionalInfoName title=this.title) }}
                 </div>
             {{/if}}
-            <a href="{{url}}" rel="canonical" aria-label="{{{link-text}}} {{{ stripOnlyScript this.title }}}">{{{link-text}}}</a>
+            <a href="{{url}}" rel="canonical" aria-label="{{{link-text}}}">{{{ stripHTMLTags this.title }}}>{{{link-text}}}</a>
         </div>
     </article>


### PR DESCRIPTION
# Description
original problem of ticket was not present on develop, but I found one another bug, there was always simple end quote at the end of text in sc-card footer 
![image](https://user-images.githubusercontent.com/40116220/92117222-33336c80-edf5-11ea-9725-d985192ee525.png)
this bug is fixed here and also aria label
## Links to Tickets or other pull requests

- https://ticketsystem.schul-cloud.org/browse/SC-6552

## Screenshots of UI changes
![image](https://user-images.githubusercontent.com/40116220/92117095-03846480-edf5-11ea-8eb1-2ec3bcd4a9fc.png)


## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
