### PR TITLE
SC-6800 - deleted name in sc-card next to open text

### DIFF
--- a/views/lib/components/sc-card.hbs
+++ b/views/lib/components/sc-card.hbs
@@ -53,6 +53,6 @@
                     {{> (concat 'lib/sc-card_additionalInfo/' additionalInfoName title=this.title) }}
                 </div>
             {{/if}}
-            <a href="{{url}}" rel="canonical" aria-label="{{{link-text}}}">{{{ stripHTMLTags this.title }}}&gt;{{{link-text}}}</a>
+            <a href="{{url}}" rel="canonical" aria-label="{{{link-text}}}">{{{link-text}}}</a>
         </div>
     </article>

--- a/views/lib/forms/paginatedForm.hbs
+++ b/views/lib/forms/paginatedForm.hbs
@@ -20,9 +20,9 @@
 	{{> "lib/components/csrfInput"}}
 
 	{{#block "buttons"}}{{/block}}
-	<button id="prevSection" class="btn btn-secondary" type="button" disabled="disabled">{{$t "global.button.back" }}</button>
-	<button id="nextSection" class="btn btn-primary pull-right" type="submit" value="Submit" data-next-label="Weiter"
-		data-submit-label="{{#unless submit-label}}Absenden{{else}}{{submit-label}}{{/unless}}">
-		{{$t "global.button.next" }}
-	</button>
+        <button id="prevSection" class="btn btn-secondary" type="button" disabled="disabled">{{$t "global.button.back" }}</button>
+        <button id="nextSection" class="btn btn-primary pull-right" type="submit" value="Submit" data-next-label="{{$t "global.button.next" }}"
+        data-submit-label="{{#unless submit-label}}{{$t "global.button.submit" }}{{else}}{{submit-label}}{{/unless}}">
+        {{$t "global.button.next" }}
+        </button>
 </form>


### PR DESCRIPTION
# Description
deleted name of card in sc-card footer,
fixed i18n missing in paginatedForm.hbs

## Links to Tickets or other pull requests

- https://ticketsystem.schul-cloud.org/browse/SC-6800

## Screenshots of UI changes
### courses
![image](https://user-images.githubusercontent.com/40116220/93314082-9b2c7e80-f809-11ea-9fcb-fc294e304eaa.png)
### teams
![image](https://user-images.githubusercontent.com/40116220/93314180-bb5c3d80-f809-11ea-8cda-5b4f3a5c7b0a.png)
### meine dateien
![image](https://user-images.githubusercontent.com/40116220/93314222-c616d280-f809-11ea-8934-e88676727edd.png)
