### PR TITLE
Hotfix/5/sc 6630 fix email validation for experts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ## Unreleased
 
+## [24.5.5] - 2020-09-22
+
+### Fixed
+
+  - SC-6630 Fixed email validation using an undefined value when inviting experts to a team.
+
 ## [24.5.4] - 2020-09-21
 
 ### Fixed

--- a/locales/de.json
+++ b/locales/de.json
@@ -2796,6 +2796,7 @@
 					"doYouReallyWantToLeaveTeam": "Möchtest du das Team wirklich verlassen?",
 					"doYouReallyWantToReSendEmail": "Möchtest du die Einladung wirklich noch einmal per E-Mail zuschicken?",
 					"editRole": "Rolle bearbeiten",
+					"email": "E-Mail",
 					"externExpert": "externer Experte",
 					"externTeacher": "Lehrer anderer Schule (Team-Admin)",
 					"federalState": "Bundesland",

--- a/locales/de.json
+++ b/locales/de.json
@@ -2796,7 +2796,7 @@
 					"doYouReallyWantToLeaveTeam": "Möchtest du das Team wirklich verlassen?",
 					"doYouReallyWantToReSendEmail": "Möchtest du die Einladung wirklich noch einmal per E-Mail zuschicken?",
 					"editRole": "Rolle bearbeiten",
-					"email": "E-Mail",
+					"email": "Einladung an diese E-Mail senden:",
 					"externExpert": "externer Experte",
 					"externTeacher": "Lehrer anderer Schule (Team-Admin)",
 					"federalState": "Bundesland",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "schulcloud-client",
-	"version": "24.5.4",
+	"version": "24.5.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "schulcloud-client",
-	"version": "24.5.4",
+	"version": "24.5.5",
 	"private": true,
 	"scripts": {
 		"start": "node ./bin/www",

--- a/static/scripts/teamMembers.js
+++ b/static/scripts/teamMembers.js
@@ -229,7 +229,7 @@ $(document).ready(() => {
 		let email;
 
 		if (state.method === 'email') {
-			email = $(this).find(`div[data-role="${state.role}"] #email`).val();
+			email = $(this).find(`div[data-role="${state.role}"] input[name=email]`).val();
 
 			if (!validateEmail(email)) {
 				$.showNotification($t('teams._team.members.add.text.pleaseEnterValidEmail'), 'danger', true);

--- a/views/teams/forms/form-invite-external-member.hbs
+++ b/views/teams/forms/form-invite-external-member.hbs
@@ -65,7 +65,7 @@
                         <li>{{$t "teams._team.members.text.invitationEmailIsEqualToRegisterEmail" (dict "rootThemeShortTitle" @root.theme.short_title)}}</li>
                     </ul>
                 </div>
-                    <label for="email">A label needed</label>
+                    <label for="email">{{$t "teams._team.members.label.email"}}</label>
                     <input class="form-control" type="text" name="email" id="email" placeholder="{{$t "teams._team.members.placeholder.insertEmail"}}">
             </div>
         </div>


### PR DESCRIPTION
Fixes undefined emails being validated during team expert invitation and a missing translation string.

Ticket: https://ticketsystem.hpi-schul-cloud.org/browse/SC-6630