### PR TITLE
SC-7085 - fixes parent consent pin request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ## Unreleased
 
+## [25.1.1] - 2020-10-15
+
+### Fixed
+
+- SC-7085 fixed importHash error when asking parent consent
+
 ## [25.0.7] - 2020-10-09
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "schulcloud-client",
-	"version": "25.1.0",
+	"version": "25.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "schulcloud-client",
-	"version": "25.1.0",
+	"version": "25.1.1",
 	"private": true,
 	"scripts": {
 		"start": "node ./bin/www",

--- a/views/firstLogin/firstLogin.hbs
+++ b/views/firstLogin/firstLogin.hbs
@@ -1,4 +1,8 @@
 {{#extend "lib/simple"}}
+{{#content "styles" mode="append"}}
+    <link rel="stylesheet" href="/styles/administration/dataprivacy.css"/>
+    <link rel="stylesheet" href="/styles/registration/pin.css" />
+{{/content}}
 {{> "firstLogin/partials/imports"}}
 {{#content "page"}}
 {{#embed "lib/forms/paginatedForm" sections=(arrayLength @root.sections) action="/firstLogin/submit" method="post" submit-label=@root.submitLabel}}

--- a/views/firstLogin/sections/pin.hbs
+++ b/views/firstLogin/sections/pin.hbs
@@ -4,4 +4,5 @@
   <div id="pinverification">
     {{#embed "registration/pin" digits=4 pattern="[0-9]" required="true" name="pin" class="mail-validation my-1"}}{{/embed}}
   </div>
+    {{#if @root.currentUser.importHash }}<input type="hidden" name="importHash" value="{{@root.currentUser.importHash}}" />{{/if}}
 </section>


### PR DESCRIPTION
# Description

When parent consent is not given, the first login wizzard takes the user to parent consent. The consent is confirmed via a PIN sent to parent email. This was not working, giving a an error about missing importHash.

Furthermore, missing css made the pin entering practically impossible for the user. 

There is a second case, when the account is via LDAP, but this case is not covered here.

<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests

- https://ticketsystem.hpi-schul-cloud.org/browse/SC-7085
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/1837
<!--
Base links to copy
- https://github.com/schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.schul-cloud.org/browse/SC-????
-->

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Data Security <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM packages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<img width="1152" alt="Screenshot 2020-10-15 at 16 00 29" src="https://user-images.githubusercontent.com/17074330/96139959-a99cb180-0eff-11eb-9d44-c04bbc80fd50.png">

<img width="1151" alt="Screenshot 2020-10-15 at 16 17 34" src="https://user-images.githubusercontent.com/17074330/96142081-f3869700-0f01-11eb-8fba-2de9524b5877.png">

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
