### PR TITLE
SC-7083 - Gets school number from admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 ### Added
 
 - SC-6870 - Added UX improvements for Matrix messenger announcement
+- SC-7083 - Added input to get the school id from admin
 
 ## [25.0.7] - 2020-10-09
 

--- a/controllers/schools.js
+++ b/controllers/schools.js
@@ -19,10 +19,11 @@ router.get('/', async (req, res, next) => {
 	try {
 		const schools = await api(req).get('/schools/', params);
 
-		const result = schools.data.map(school => ({
+		const result = schools.data.map((school) => ({
 			_id: school._id,
 			name: school.name,
 			purpose: school.purpose,
+			officialSchoolNumber: school.officialSchoolNumber,
 		}));
 
 		return res.json(result);

--- a/locales/de.json
+++ b/locales/de.json
@@ -573,6 +573,7 @@
 				"noteBeforeTheTransferPhase": "Beachte vor der Transferphase:",
 				"passwordChangesInLDAP": "Kennwortänderungen im LDAP",
 				"privacySettings": "Datenschutz-Einstellungen",
+				"schoolNumber": "Schulnummer:",
 				"schoolYear": "Schuljahr:",
 				"schoolYearChange": "Schuljahreswechsel",
 				"selectProvider": "Anbieter auswählen",

--- a/locales/en.json
+++ b/locales/en.json
@@ -573,6 +573,7 @@
 				"noteBeforeTheTransferPhase": "Note before the transfer phase:",
 				"passwordChangesInLDAP": "Password changes in LDAP",
 				"privacySettings": "Privacy Settings",
+				"schoolNumber": "School number:",
 				"schoolYear": "School year:",
 				"schoolYearChange": "Change of school year",
 				"selectProvider": "Select provider",

--- a/views/administration/school.hbs
+++ b/views/administration/school.hbs
@@ -192,6 +192,14 @@
 						</div>
 
 						<div class="form-group">
+							<label>{{$t "administration.school.label.schoolNumber" }}</label>
+							<input value="{{../school.officialSchoolNumber}}" type="text" pattern="\D{0,2}-*\d{5}$" class="form-control" name="officialSchoolNumber"
+								placeholder="12345" {{#if ../schoolUsesLdap}} readonly{{/if}}
+								{{#if ../isExpertSchool}} readonly{{/if}} {{#userHasPermission 'SCHOOL_EDIT'}}{{else}}
+								readonly{{/userHasPermission}}/>
+						</div>
+
+						<div class="form-group">
 							<label>{{$t "administration.school.label.uploadSchoolLogo" }}</label><br />
 							<input type="hidden" name="logo_dataUrl">
 							<input type="file" id="logo-input">


### PR DESCRIPTION
# Description

Creates input to type the school id in the school administration for users who have admin permissions.

## Links to Tickets or other pull requests
https://github.com/hpi-schul-cloud/schulcloud-server/pull/1833
https://ticketsystem.hpi-schul-cloud.org/browse/SC-7083

## Changes
Adds school id input text input to type the school id in the school administration view.


## Screenshots of UI changes
<img width="1785" alt="Screenshot 2020-10-15 at 15 47 57" src="https://user-images.githubusercontent.com/2567952/96138361-ff705a00-0efd-11eb-99de-c10f7d736496.png">

## Approval for review
- [X] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
