### PR TITLE
Feature/sc 7447 add warning text leaving sc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Added
 
+- SC-7447 - Add warning text for links when leaving the schul-cloud platform
 - SC-6293 - added option to school admin to disable lernstore for students
 
 ### Fixed

--- a/locales/de.json
+++ b/locales/de.json
@@ -2977,7 +2977,9 @@
 				"titleOfTheTopic": "Titel des Themas"
 			},
 			"text": {
-				"shareWithOthersTeachers": "mit anderen Lehrern teilen"
+				"shareWithOthersTeachers": "mit anderen Lehrern teilen",
+				"warningMain": "Hinweis: Beim Klicken des Links verlassen Sie das Angebot der Schul-Cloud",
+				"warningFooter": "Die Nutzung dieser Angebote unterliegt gegebenenfalls anderen rechtlichen Bedingungen. Bitte schauen Sie daher in die Datenschutzerklärung des externen Anbieters!"
 			}
 		},
 		"aria_label" :{

--- a/locales/en.json
+++ b/locales/en.json
@@ -2977,7 +2977,9 @@
 				"titleOfTheTopic": "Title of the topic"
 			},
 			"text": {
-				"shareWithOthersTeachers": "share with other teachers"
+				"shareWithOthersTeachers": "share with other teachers",
+				"warningMain": "Note: Clicking the link will take you away from Schul-Cloud",
+				"warningFooter": "The use of these offers may be subject to other legal conditions. Therefore, please take a look at the privacy policy of the external provider!"
 			}
 		},
 		"aria_label": {

--- a/static/scripts/topicEdit.js
+++ b/static/scripts/topicEdit.js
@@ -535,10 +535,8 @@ class TopicResource extends React.Component {
                     <p className="card-text">{(this.props.resource || {}).description}</p>
                 </div>
                 <div className="card-footer">
-					/**
-					* Show proper provider.
-					* TODO: show a real provider instead of Schul-cloud once they are available
-					*/
+					{/* Show proper provider.
+					TODO: show a real provider instead of Schul-cloud once they are available */}
                     {/* <small className="text-muted">via {(this.props.resource || {}).client}</small> */}
                     <a className="btn-remove-resource" onClick={this.props.onRemove}><i
                         className="fa fa-trash-o"></i></a>

--- a/static/styles/courses/course.scss
+++ b/static/styles/courses/course.scss
@@ -113,6 +113,10 @@
 		}
 	}
 
+	.external-source-warning {
+		color: $colorDanger;
+	}
+
 	.files {
 		margin-bottom: 20px;
 	}

--- a/views/topic/components/content-resources.hbs
+++ b/views/topic/components/content-resources.hbs
@@ -9,12 +9,16 @@
                     <a href="{{url}}" target="_blank">
                         {{title}}
                     </a>
+                    <div class="external-source-warning">
+                        <h5>{{$t "topic._topic.text.warningMain" }}</h5>
+                        <h6>{{$t "topic._topic.text.warningFooter" }}</h6>
+                    </div>
                 </h4>
                 <p class="card-text">{{description}}</p>
             </div>
-            <div class="card-footer">
+            {{!-- <div class="card-footer">
                 <small class="text-muted">via {{client}}</small>
-            </div>
+            </div> --}}
         </div>
     {{/each}}
 

--- a/views/topic/topic.hbs
+++ b/views/topic/topic.hbs
@@ -69,6 +69,10 @@
                                         <a href="{{this.url}}" target="_blank">
                                             {{this.title}}
                                         </a>
+                                        <div class="external-source-warning">
+                                            <h5>{{$t "topic._topic.text.warningMain" }}</h5>
+                                            <h6>{{$t "topic._topic.text.warningFooter" }}</h6>
+                                        </div>
                                     </h2>
                                     <p class="card-text">{{this.description}}</p>
                                     {{#if this.download}}
@@ -78,7 +82,7 @@
                                     {{/if}}
                                 </div>
                                 <div class="card-footer">
-                                    <small class="text-muted"> via {{this.client}}</small>
+                                    {{!-- <small class="text-muted"> via {{this.client}}</small> --}}
                                     {{#userHasPermission "COURSE_EDIT"}}
                                         <a class="delete-material" href="materials/{{../_id}}" target="_blank"
                                             data-method="DELETE" data-name="{{../title}}">


### PR DESCRIPTION
# Description
## Links to Tickets or other pull requests
Ticket: https://ticketsystem.hpi-schul-cloud.org/browse/SC-7447
Client: https://github.com/hpi-schul-cloud/schulcloud-client/compare/Feature/SC-7447-add-warning-text-leaving-sc?expand=1
Nuxt: https://github.com/hpi-schul-cloud/nuxt-client/compare/Feature/SC-7447-add-warning-text-leaving-sc?expand=1

The pr adds a warning text required by stake holders to warn users when they leave schul-cloud.
## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

<img width="807" alt="client" src="https://user-images.githubusercontent.com/32653149/97001392-98bff180-1538-11eb-992e-126d7750f3d6.png">
<img width="479" alt="nuxt" src="https://user-images.githubusercontent.com/32653149/97001402-9bbae200-1538-11eb-90b3-e4e22f2d818d.png">


