### PR TITLE
hotfix/4/SC-6735 fix place of disabled property in hbs file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ## Unreleased
 
-## [25.2.0] - 2020-10-26
+## [25.1.4] - 2020-10-26
+
+### Fixed
+
+- SC-6735 additional fix - administration remove consent triggers import hash generation
+
+## [25.1.3] - 2020-10-26
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ## Unreleased
 
-## [25.1.3] - 2020-10-21
+## [25.2.0] - 2020-10-26
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "schulcloud-client",
-	"version": "25.2.0",
+	"version": "25.1.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "schulcloud-client",
-	"version": "25.1.3",
+	"version": "25.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "schulcloud-client",
-	"version": "25.1.3",
+	"version": "25.2.0",
 	"private": true,
 	"scripts": {
 		"start": "node ./bin/www",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "schulcloud-client",
-	"version": "25.2.0",
+	"version": "25.1.4",
 	"private": true,
 	"scripts": {
 		"start": "node ./bin/www",

--- a/views/administration/users_edit.hbs
+++ b/views/administration/users_edit.hbs
@@ -115,11 +115,13 @@
                                         <button class="btn btn-secondary btn-delete">{{$t "administration.users_edit.headline.deleteUser" }}</button>
                                     {{/if}}
                                     <button class="btn btn-secondary btn-invitation-link-with-hash {{#if editTeacher}}teacher{{else}}student{{/if}}"
-                                    {{#ifeq consentStatusIcon '<i class="fa fa-check consent-status double-check"></i><i class="fa fa-check consent-status double-check"></i>'}}disabled={{hasAccount}} title="{{$t "administration.users_edit.button.alreadyRegistered" }}"{{/ifeq}}>
+                                    disabled={{hasAccount}}
+                                    {{#ifeq consentStatusIcon '<i class="fa fa-check consent-status double-check"></i><i class="fa fa-check consent-status double-check"></i>'}} title="{{$t "administration.users_edit.button.alreadyRegistered" }}"{{/ifeq}}>
                                         {{$t "administration.button.generatePersonalInvitationLink" }}
                                     </button>
                                     <button class="btn btn-secondary btn-send-link-email {{#if editTeacher}}teacher{{else}}student{{/if}}"
-                                    {{#ifeq consentStatusIcon '<i class="fa fa-check consent-status double-check"></i><i class="fa fa-check consent-status double-check"></i>'}}disabled={{hasAccount}} title="{{$t "administration.users_edit.button.alreadyRegistered" }}"{{/ifeq}}>
+                                    disabled={{hasAccount}}
+                                    {{#ifeq consentStatusIcon '<i class="fa fa-check consent-status double-check"></i><i class="fa fa-check consent-status double-check"></i>'}} title="{{$t "administration.users_edit.button.alreadyRegistered" }}"{{/ifeq}}>
                                         {{$t "administration.button.sendTheInvitationLinkByMail" }}
                                     </button>
                                 {{/unless}}


### PR DESCRIPTION
# Description
Steps to reproduce:

Go to Students table
Select a student with consent
Open the maintenance screen and remove the student's consent

Actual result:
The registration hash/link is generated and 2 buttons (Persönlichen Einladungslink generieren, Einladungslink per E-Mail versenden) are active.

Expected result:
No link is generated, the button stays disabled.
The Link should never be generated (no matter what) if the user has already an account.

## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/SC-6735

## Changes
Disable buttons for hash generation and email link from student edit page in case there is an account

## Data Security <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>

## Deployment

## New Repos, NPM packages or vendor scripts

## Screenshots of UI changes

![94680147-91366f80-0321-11eb-892e-af92f6cafc6a](https://user-images.githubusercontent.com/11357308/97020678-22c88400-1552-11eb-836c-3e20ec7e2cce.png)


## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
