### PR TITLE
Show correct age options while registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 - SC-6721 - fixed classes list in course administration
 - SC-7084 - changed file permission name Mitglied to Teilnehmer
 - SC-5501 - fixed grammar issue for password recovery request
+- SC-7589 - fixed correct display for age while first login and change of sentence structure for clearance
 
 ### Changed
 

--- a/locales/de.json
+++ b/locales/de.json
@@ -1462,7 +1462,7 @@
 		"label": {
 			"newPassword": "Neues Passwort: ",
 			"repeatYourNewPassword": "Wiederhole dein neues Passwort:",
-			"under14YearsOld": "unter 14 Jahre alt."
+			"under14YearsOld": "13 Jahre oder jünger."
 		},
 		"parent": {
 			"button": {
@@ -1503,9 +1503,9 @@
 			"repeatNewPassword": "Neues Passwort wiederholen"
 		},
 		"text": {
-			"between14And": "zwischen 14 und {{addConsent}} Jahre alt.",
+			"between14And": "zwischen 14 und {{addConsent}} Jahre.",
 			"clickHereForFurtherTraining": "Hier gehts zur Fortbildung",
-			"fromYear": "ab {{age}} Jahre alt.",
+			"fromYear": "{{age}} Jahre oder älter.",
 			"justHaveALook": "Schau einfach mal vorbei!",
 			"linguisticNote": "Sprachlicher Hinweis: Für bessere Lesbarkeit verwenden wir in der {{shortTitle}} die männliche Form (z.B. „Schüler“, „Lehrer“). Es sind stets alle Personen unabhängig vom Geschlecht gemeint. Die {{shortTitle}} ist für alle Menschen da, unabhängig von Herkunft, Einschränkungen, Geschlecht und sexueller Orientierung.",
 			"pleaseChangeTheStartPassword": "Bitte ändere das Startpasswort. Notiere dir das neue Passwort gleich und bewahre es gut auf!",
@@ -2591,8 +2591,8 @@
 				"welcomeToTheRegistration": "Willkommen zur Anmeldung in der {{title}}!"
 			},
 			"label": {
-				"bellowNYearsOld": "unter {{years}} Jahre alt",
-				"overNYearsOld": "ab {{years}} Jahre alt"
+				"bellowNYearsOld": "unter {{years}} Jahren.",
+				"overNYearsOld": "{{years}} Jahre oder älter."
 			},
 			"parent": {
 				"global": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -1462,7 +1462,7 @@
 		"label": {
 			"newPassword": "New password:",
 			"repeatYourNewPassword": "Repeat your new password:",
-			"under14YearsOld": "under 14 years old."
+			"under14YearsOld": "13 years or younger."
 		},
 		"parent": {
 			"button": {
@@ -1503,9 +1503,9 @@
 			"repeatNewPassword": "Repeat new password"
 		},
 		"text": {
-			"between14And": "between 14 and {{addConsent}} years old.",
+			"between14And": "between 14 and {{addConsent}} years.",
 			"clickHereForFurtherTraining": "Click here for further training",
-			"fromYear": "from {{age}} years old.",
+			"fromYear": "{{age}} years or older.",
 			"justHaveALook": "Just have a look!",
 			"linguisticNote": "Linguistic note: For better readability we use the masculine form in the {{shortTitle}} (e.g. \"student\", \"teacher\"). It always refers to all persons regardless of gender. The {{shortTitle}} is meant for all people regardless of origin, restrictions, gender and sexual orientation.",
 			"pleaseChangeTheStartPassword": "Please change the start password. Make a note of the new password and keep it safe!",
@@ -2591,8 +2591,8 @@
 				"welcomeToTheRegistration": "Welcome to the registration in the {{title}}!"
 			},
 			"label": {
-				"bellowNYearsOld": "under {{years}} years old",
-				"overNYearsOld": "from {{years}} years old"
+				"bellowNYearsOld": "under {{years}} years.",
+				"overNYearsOld": "{{years}} years or older."
 			},
 			"parent": {
 				"global": {

--- a/views/firstLogin/firstLoginExistingUser.hbs
+++ b/views/firstLogin/firstLoginExistingUser.hbs
@@ -13,7 +13,7 @@
       <div class="form-group">
           <fieldset>
               <input type="radio" id="reg-u14" name="student-age" value="u14"> <label for="reg-u14">{{$t "firstLogin.label.under14YearsOld" }}</label><br/>
-              <input type="radio" id="reg-1415" name="student-age" value="1415"> <label for="reg-1415">{{$t "firstLogin.text.between14And" (dict "addConsent" add CONSENT_WITHOUT_PARENTS_MIN_AGE_YEARS -1 )}}</label><br>
+              <input type="radio" id="reg-1415" name="student-age" value="1415"> <label for="reg-1415">{{$t "firstLogin.text.between14And" (dict "addConsent" (add CONSENT_WITHOUT_PARENTS_MIN_AGE_YEARS -1 ))}}</label><br>
               <input type="radio" id="reg-16" name="student-age" value="16"> <label for="reg-16">{{$t "firstLogin.text.fromYear" (dict "age" CONSENT_WITHOUT_PARENTS_MIN_AGE_YEARS )}}</label>
           </fieldset>
       </div>


### PR DESCRIPTION
# Description
<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and end-to-end-tests), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->
While first login there was no max option shown for the second age range for users with existing account but missing birthday and consent. Also the grammar was not always clear for the range of ages during registration or first login.
## Links to Tickets or other pull requests
<!--
Base links to copy
- https://github.com/schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.schul-cloud.org/browse/SC-????
-->
https://ticketsystem.hpi-schul-cloud.org/browse/SC-7589
## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->
- fix code for correct age range
- change sentence structure in de and en for clearance
## Data Security <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data security team.
-->
No data security topics.
## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM packages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes
<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->
![image](https://user-images.githubusercontent.com/55735359/98240784-3c15fb00-1f6a-11eb-8902-9f284eab8721.png)

![image](https://user-images.githubusercontent.com/55735359/98240809-4637f980-1f6a-11eb-951e-9cafa3bea6b3.png)

## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
