### PR TITLE
Bugfix/SC-7453 - Course/team event doesn't display course/team information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Fixed
 
+- SC-7453 - fixed course/team event handling
 - SC-7353 - fixed course sharing between teachers
 - SC-7645 - Fixed team calendar timezone bug
 - SC-7666 - Fixed rss translation key

--- a/static/scripts/calendar.js
+++ b/static/scripts/calendar.js
@@ -99,27 +99,27 @@ $(document).ready(() => {
 			const startDate = toMoment(event.start, calendar).format($t('format.dateTimeToPicker'));
 			const endDate = toMoment(event.end || event.start, calendar).format($t('format.dateTimeToPicker'));
 
-			const { attributes } = event.extendedProps || {};
+			const eventData = event.extendedProps || {};
 
 			populateModalForm($editEventModal, {
 				title: $t('global.headline.dateDetails'),
 				closeLabel: $t('global.button.cancel'),
 				submitLabel: $t('global.button.save'),
 				fields: {
-					summary: attributes.summary,
+					summary: eventData.summary,
 					startDate,
 					endDate,
-					description: attributes.description,
-					location: attributes.location,
+					description: eventData.description,
+					location: eventData.location,
 				},
-				action: `/calendar/events/${attributes.uid}`,
+				action: `/calendar/events/${eventData._id}`,
 			});
 
-			if (!event['x-sc-teamId']) { // course or non-course event
-				transformCourseOrTeamEvent($editEventModal, event);
+			if (!eventData['x-sc-teamId']) { // course or non-course event
+				transformCourseOrTeamEvent($editEventModal, eventData);
 				$editEventModal.find('.btn-delete').click(() => {
 					$.ajax({
-						url: `/calendar/events/${attributes.uid}`,
+						url: `/calendar/events/${eventData._id}`,
 						type: 'DELETE',
 						error: showAJAXError,
 						success(result) {
@@ -130,8 +130,8 @@ $(document).ready(() => {
 				$editEventModal.appendTo('body').modal('show');
 			}
 
-			if (event['x-sc-teamId']) { // team event
-				const teamId = event['x-sc-teamId'];
+			if (eventData['x-sc-teamId']) { // team event
+				const teamId = eventData['x-sc-teamId'];
 				window.location.assign(`/teams/${teamId}?activeTab=events`);
 			}
 


### PR DESCRIPTION
# Description

 Note:

I have checked the calendar event generation for teams and courses. But it will work like this:

## Course Event
1. You create or edit a event and select a course
2. The course will be assigned to this event
3. You edit this course event
4. The course name will appear in the title
5. the course and team selection is removed. Removed for the rest of the calendar session
=> You can't switch to another course

## Team Event
1. You create or edit a event and select a team
2. The team will be assigned to this event
3. You edit this team event
4. You will be immediately redirected to the teams page on tab events
=> You can't switch to another team



<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and end-to-end-tests), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/SC-7453

<!--
Base links to copy
- https://github.com/schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.schul-cloud.org/browse/SC-????
-->

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Data Security <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM packages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes
<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
