### PR TITLE
SC-5179 - CKEditor on Task images selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Fixed
 
+- SC-5179 - Fixed CKEditor on homework to insert images from Course instead of My Files 
 - SC-7667 - Fixed help desk displays my own local time
 - SC-7652 - Fixed teacher creates a calendar in team then Dashboard empty
 - SC-7353 - fixed course sharing between teachers

--- a/static/scripts/ckeditor/ckeditor.js
+++ b/static/scripts/ckeditor/ckeditor.js
@@ -1,18 +1,51 @@
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 import ckeditorConfig from './ckeditor-config';
 
-window.addEventListener('DOMContentLoaded', async () => {
-	document.querySelectorAll('.ckeditor').forEach(async (element) => {
-		const editor = await ClassicEditor.create(element, ckeditorConfig);
-		editor.model.document.on('change:data', () => {
-			const submitButton = document.querySelector('.ckeditor-submit');
-			if (submitButton) {
-				const editorContent = editor.getData();
-				const editorContainsText = editorContent !== '';
-				submitButton.setAttribute('editorContainsText', editorContainsText);
-				const fileIsUploaded = submitButton.getAttribute('fileIsUploaded');
-				submitButton.disabled = !editorContainsText && !fileIsUploaded;
+const url = window.location.pathname;
+const urlParts = url.split("/");
+
+const setStorageContext = () => {
+	if (urlParts[1] === "homework") {
+		let storageContext;
+		if (urlParts[2] === 'new' || urlParts[3] === "edit") {
+			const course = document.getElementById("coursePicker").value;
+			storageContext = `/files/courses/${course}`;
+			if (!course) {
+				// Show error
+				storageContext = `/files/courses/`;
 			}
-		});
+		} else {
+			storageContext =
+				document.getElementById("courseId").getAttribute("href") ||
+				"courses";
+		}
+		ckeditorConfig.filebrowser.browseUrl = `${storageContext}`;
+	}
+}
+
+const initEditor = async (element) => {
+	setStorageContext();
+	const editor = await ClassicEditor.create(element, ckeditorConfig);
+
+	if (urlParts[1] === "homework" && (urlParts[2] === 'new' || urlParts[3] === "edit")) {
+		document.getElementById("coursePicker").onchange = async function () {
+			await editor.destroy(element);
+			await initEditor(element);
+		};
+	}
+
+	editor.model.document.on("change:data", () => {
+		const submitButton = document.querySelector(".ckeditor-submit");
+		if (submitButton) {
+			const editorContent = editor.getData();
+			const editorContainsText = editorContent !== "";
+			submitButton.setAttribute("editorContainsText", editorContainsText);
+			const fileIsUploaded = submitButton.getAttribute("fileIsUploaded");
+			submitButton.disabled = !editorContainsText && !fileIsUploaded;
+		}
 	});
+};
+
+window.addEventListener('DOMContentLoaded', async () => {
+	document.querySelectorAll('.ckeditor').forEach(async (element) => await initEditor(element));
 });

--- a/views/homework/assignment.hbs
+++ b/views/homework/assignment.hbs
@@ -93,7 +93,7 @@
             {{#if courseId._id}}
                 <div class="col-sm-12">
                     <div class="pull-right">
-                        <a href="/files/courses/{{courseId._id}}" class="btn btn-add btn-secondary">
+                        <a id="courseId" href="/files/courses/{{courseId._id}}" class="btn btn-add btn-secondary">
                             <i class="fa fa-folder-open"></i>
                             {{$t "homework.button.toTheCourseFiles" }}
                         </a>


### PR DESCRIPTION
# Description

IN Tasks (homework) the CKEditor insert image button, shows the "Server durchsuchen" button, which was leading to My Files  instead of Course. 
This fix allows students to upload files which are stored in the Course the task belongs to, instead of their private files, thus avoiding permission problems.

<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and end-to-end-tests), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/SC-5179
<!--
Base links to copy
- https://github.com/schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.schul-cloud.org/browse/SC-????
-->

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Data Security <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM packages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes
<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
