### PR TITLE
SC-5498 - fixed a source for shortTitle of instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Fixed
 
+- SC-5498 - Fixed typo in account page
 - SC-1589 - Fixed error handling on team creation
 - SC-7845 - Fixed GitHub action changelog
 - SC-7859 - Fixed class name not required to create a class

--- a/locales/de.json
+++ b/locales/de.json
@@ -88,7 +88,7 @@
 				"TEACHER_VISIBILITY_FOR_EXTERNAL_TEAM_INVITATION_opt-out": "Sichtbarkeit im zentralen Verzeichnis deaktivieren"
 			},
 			"text": {
-				"hintVisibility": "Lehrkräfte anderer Schulen, die Teamadministratoren sind, können dich über den zentralen Verzeichnisdienst der {{short_title}} bequem in ein schulübergreifendes Team einladen. Dein Name ist dabei deiner Schule zugeordnet und in der Verzeichnisstruktur unter <i>Name deines Bundeslandes &raquo; Name deiner Schule &raquo; dein Name</i> aufrufbar.",
+				"hintVisibility": "Lehrkräfte anderer Schulen, die Teamadministratoren sind, können dich über den zentralen Verzeichnisdienst der {{shortTitle}} bequem in ein schulübergreifendes Team einladen. Dein Name ist dabei deiner Schule zugeordnet und in der Verzeichnisstruktur unter <i>Name deines Bundeslandes &raquo; Name deiner Schule &raquo; dein Name</i> aufrufbar.",
 				"visibilityTeamInvitationsDisabled": "Sichtbarkeit für Teameinladungen ist deaktiviert",
 				"visibilityTeamInvitations": "Sichtbarkeit für Teameinladungen"
 			}

--- a/locales/en.json
+++ b/locales/en.json
@@ -88,7 +88,7 @@
 				"TEACHER_VISIBILITY_FOR_EXTERNAL_TEAM_INVITATION_opt-out": "Deactivate visibility in the central directory"
 			},
 			"text": {
-				"hintVisibility": "Teachers from other schools who are team administrators can easily invite you to a cross-school team via the central directory service of {{short_title}}. Your name is assigned to your school and it is accessible in the directory structure under <i> Name of your state &raquo; Name of your school &raquo; Your name </i>.",
+				"hintVisibility": "Teachers from other schools who are team administrators can easily invite you to a cross-school team via the central directory service of {{shortTitle}}. Your name is assigned to your school and it is accessible in the directory structure under <i> Name of your state &raquo; Name of your school &raquo; Your name </i>.",
 				"visibilityTeamInvitationsDisabled": "Visibility for team invitations is disabled",
 				"visibilityTeamInvitations": "Visibility for team invitations"
 			}

--- a/views/account/settings.hbs
+++ b/views/account/settings.hbs
@@ -117,7 +117,7 @@
                 <h2 class="h5">{{$t "global.link.teams"}}</h2>
                     <div class="form-group">
                         {{$t "account.teams.text.visibilityTeamInvitations" }}
-                        <p class="text-muted">{{{$t "account.teams.text.hintVisibility" (dict "short_title" theme.short_title )}}}</p>
+                        <p class="text-muted">{{$t "account.teams.text.hintVisibility" (dict "shortTitle" @root.theme.short_title )}}</p>
 
                         {{#ifConfig "TEACHER_VISIBILITY_FOR_EXTERNAL_TEAM_INVITATION" "enabled"}}<label>{{$t "account.teams.label.TEACHER_VISIBILITY_FOR_EXTERNAL_TEAM_INVITATION_enabled"}}</label>{{/ifConfig}}
 

--- a/views/account/teams.hbs
+++ b/views/account/teams.hbs
@@ -22,7 +22,7 @@
                     <div class="form-group">
                         {{$t "account.teams.text.visibilityTeamInvitations"}}
                         <p class="text-muted">
-                            {{$t "account.teams.text.hintVisibility" (dict "short_title" @root.theme.short_title )}}
+                            {{$t "account.teams.text.hintVisibility" (dict "shortTitle" @root.theme.short_title )}}
                         </p>
 
                         {{#ifConfig "TEACHER_VISIBILITY_FOR_EXTERNAL_TEAM_INVITATION" "enabled"}}<label>{{$t "account.teams.label.TEACHER_VISIBILITY_FOR_EXTERNAL_TEAM_INVITATION_enabled"}}</label>{{/ifConfig}}


### PR DESCRIPTION
# Description
missing word on account page

## Links to Tickets or other pull requests
- https://ticketsystem.schul-cloud.org/browse/SC-5498


## Screenshots of UI changes
### fix
![image](https://user-images.githubusercontent.com/40116220/99971745-e761e500-2d9d-11eb-9be9-af80d76525cc.png)

