### PR TITLE
SC-7771 - wrong hint for teachers on edit course

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Added
 
+- SC-6825 - change collapsable icon
 - SC-6662 - Add data-testid in homework for integration test
 - SC-7571 - fixed registration link generation (performance issues)
 - SC-7447 - Add warning text for links when leaving the schul-cloud platform

--- a/static/scripts/base.js
+++ b/static/scripts/base.js
@@ -194,11 +194,11 @@ $(document).ready(() => {
 			$collapseToggle
 				.find('.collapse-icon')
 				.removeClass('fa-chevron-right');
-			$collapseToggle.find('.collapse-icon').addClass('fa-chevron-down');
+			$collapseToggle.find('.collapse-icon').addClass('fa-chevron-up');
 		} else {
 			$collapseToggle
 				.find('.collapse-icon')
-				.removeClass('fa-chevron-down');
+				.removeClass('fa-chevron-up');
 			$collapseToggle.find('.collapse-icon').addClass('fa-chevron-right');
 		}
 	}

--- a/views/authentication/forms/login.hbs
+++ b/views/authentication/forms/login.hbs
@@ -36,7 +36,7 @@
 
 
                 <button type="button" title="{{$t "login.button.moreOptions"}}" class="btn form-group toggle-btn btn-block btn-secondary btn-toggle-providers ">
-                    <i aria-hidden="true" class="fa fa-chevron-down"></i> {{$t "login.button.moreOptions"}}
+                    <i aria-hidden="true" class="fa fa-chevron-up"></i> {{$t "login.button.moreOptions"}}
                 </button>
 
 

--- a/views/courses/edit-course.hbs
+++ b/views/courses/edit-course.hbs
@@ -121,7 +121,7 @@
 				<div class="form-group">
 					<label>{{$t "courses.global.label.courseTeacher"}}</label>
 
-					<select name="teacherIds[]" required multiple data-placeholder="{{$t "courses.global.input.selectStudents"}}"
+					<select name="teacherIds[]" required multiple data-placeholder="{{$t "courses.global.input.chooseTeacher"}}"
 						{{#if course.isArchived}}disabled{{/if}}>
 						{{#each teachers}}
 							<option value="{{this._id}}" {{#if this.selected}}selected{{/if}}>

--- a/views/help/partials/help_confluence_links.hbs
+++ b/views/help/partials/help_confluence_links.hbs
@@ -26,7 +26,7 @@
 							<button class="collapse__title collapsed" data-toggle="collapse" data-target="#collapsable-{{this.id}}"
 								aria-expanded="false" aria-controls="collapsable-{{this.id}}" type="button" tabindex="0">
 								<i class="fa fa-fw fa-chevron-right" aria-hidden="true" data-expand></i>
-								<i class="fa fa-fw fa-chevron-down" aria-hidden="true" data-collapse></i>
+								<i class="fa fa-fw fa-chevron-up" aria-hidden="true" data-collapse></i>
 								<h3 class="h5 collapsable-headline">
 									{{this.title}}
 								</h3>

--- a/views/homework/assignment.hbs
+++ b/views/homework/assignment.hbs
@@ -10,8 +10,8 @@
                 $(this).parent('.usersubmission:not(.clicked)').toggleClass('active');
                 $('.usersubmission.clicked').removeClass('clicked');
 
-                $('.usersubmission td:last-of-type i.fa-chevron-down').removeClass('fa-chevron-down').addClass('fa-chevron-left');
-                $('.usersubmission.active td:last-of-type i.fa-chevron-left').removeClass('fa-chevron-left').addClass('fa-chevron-down');
+                $('.usersubmission td:last-of-type i.fa-chevron-up').removeClass('fa-chevron-up').addClass('fa-chevron-down');
+                $('.usersubmission.active td:last-of-type i.fa-chevron-down').removeClass('fa-chevron-down').addClass('fa-chevron-up');
             });
 
             // change tab

--- a/views/homework/submissions.hbs
+++ b/views/homework/submissions.hbs
@@ -44,7 +44,7 @@
                                 {{/if}}
                             {{/if}}
                         </td>
-                        <td><i class="fa fa-chevron-left" aria-hidden="true"/></td>
+                        <td><i class="fa fa-chevron-down" aria-hidden="true"/></td>
                     </tr>
                     <tr class="evaluation">
                         <td colSpan="6">{{>"homework/evaluation"}}</td>
@@ -86,7 +86,7 @@
                         </td>
                         <td>
                             {{#if this.submission}}
-                                <i class="fa fa-chevron-left" aria-hidden="true"/>
+                                <i class="fa fa-chevron-down" aria-hidden="true"/>
                             {{/if}}
                         </td>
                     </tr>


### PR DESCRIPTION
# Description
Editing the teacher of a course suggests adding a student:in in the text field. Only teachers can be selected.


## Links to Tickets or other pull requests
- https://ticketsystem.schul-cloud.org/browse/SC-7771

## Screenshots of UI changes
