### PR TITLE
SC-7771 - wrong hint for teachers on edit course

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Fixed
 
+- SC-7771 - Fixed hint for teachers when editing a course
 - SC-1589 - Fixed error handling on team creation
 - SC-7845 - Fixed GitHub action changelog
 - SC-7859 - Fixed class name not required to create a class

--- a/views/courses/create-course.hbs
+++ b/views/courses/create-course.hbs
@@ -88,7 +88,8 @@
                     <label for="courseTeacher">{{$t "courses.global.label.courseTeacher"}}</label>
 
                     <select id="courseTeacher" name="teacherIds[]" required multiple data-placeholder= "{{$t "courses.global.input.chooseTeacher"}}" data-testid="teachersearch" autocomplete="off">
-                        {{#each teachers}}
+                    <option disabled value="{{$t "administration.global.label.noSubTeacherSelection"}}">{{$t "administration.global.label.noSubTeacherSelection"}}</option>
+            {{#each teachers}}
                             <option data-testid="teacher" value="{{this._id}}" {{#if this.selected}}selected{{/if}}>
                                 {{#if this.displayName}}
                                     {{this.displayName}}

--- a/views/courses/edit-course.hbs
+++ b/views/courses/edit-course.hbs
@@ -121,7 +121,7 @@
 				<div class="form-group">
 					<label>{{$t "courses.global.label.courseTeacher"}}</label>
 
-					<select name="teacherIds[]" required multiple data-placeholder="{{$t "courses.global.input.selectStudents"}}"
+					<select name="teacherIds[]" required multiple data-placeholder="{{$t "courses.global.input.chooseTeacher"}}"
 						{{#if course.isArchived}}disabled{{/if}}>
 						{{#each teachers}}
 							<option value="{{this._id}}" {{#if this.selected}}selected{{/if}}>


### PR DESCRIPTION
# Description
Editing the teacher of a course suggests adding a student:in in the text field. Only teachers can be selected.


## Links to Tickets or other pull requests
- https://ticketsystem.schul-cloud.org/browse/SC-7771
 
## Screenshot
![image](https://user-images.githubusercontent.com/40116220/100209163-d3d38d00-2f09-11eb-8ddd-303802280f07.png)
