### PR TITLE
SC-7771 - wrong hint for teachers- fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Fixed
 
+- SC-7771 - Fixed hint for teachers when editing a course - fix
 - SC-7771 - Fixed hint for teachers when editing a course
 - SC-5498 - Fixed typo in account page
 - SC-7842 - Fixed typo on about page

--- a/views/courses/edit-course.hbs
+++ b/views/courses/edit-course.hbs
@@ -121,7 +121,7 @@
 				<div class="form-group">
 					<label for="teacherId">{{$t "courses.global.label.courseTeacher"}}</label>
 
-					<select id="teacherId" name="teacherIds[]" required multiple data-placeholder="{{$t "courses.global.input.selectStudents"}}"
+					<select id="teacherId" name="teacherIds[]" required multiple data-placeholder="{{$t "courses.global.input.chooseTeacher"}}"
 						{{#if course.isArchived}}disabled{{/if}}>
 						{{#each teachers}}
 							<option value="{{this._id}}" {{#if this.selected}}selected{{/if}}>


### PR DESCRIPTION
# Description
Editing the teacher of a course suggests adding a student:in in the text field. Only teachers can be selected.
FIX

## Links to Tickets or other pull requests
- https://ticketsystem.schul-cloud.org/browse/SC-7771
 
## Screenshot
![image](https://user-images.githubusercontent.com/40116220/100445599-a7f10c80-30ad-11eb-9490-34c8358bf4c0.png)

