### PR TITLE
SC-6975 - Fertig button instead of zuruck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Fixed
 
+- SC-6975 - Fixed button text on declare consent
 - SC-7900 - Fixed text for inviting experts
 - SC-7983 - Fixed that topic is now choosable after select of course
 - SC-7771 - Fixed hint for teachers when editing a course - fix

--- a/controllers/administration.js
+++ b/controllers/administration.js
@@ -740,7 +740,7 @@ const skipRegistration = (req, res, next) => {
 	}).then(() => {
 		res.render('administration/users_registrationcomplete', {
 			title: res.$t('administration.controller.text.agreementSuccessfullyDeclared'),
-			submitLabel: res.$t('global.button.back'),
+			submitLabel: res.$t('global.button.done'),
 			users: [
 				{
 					email: req.body.email,

--- a/locales/de.json
+++ b/locales/de.json
@@ -1579,6 +1579,7 @@
 			"createFirstCourse": "Erstelle deinen ersten Kurs",
 			"createFolder": "Ordner erstellen",
 			"deleteTeam": "Team löschen",
+			"done": "Fertig",
 			"edit": "Bearbeiten",
 			"editTopic": "Thema bearbeiten",
 			"filterAdd": "Filter hinzufügen",

--- a/locales/en.json
+++ b/locales/en.json
@@ -1579,6 +1579,7 @@
 			"createFirstCourse": "Create your first course",
 			"createFolder": "Create folder",
 			"deleteTeam": "Delete team",
+			"done": "Done",
 			"edit": "Edit",
 			"editTopic": "Edit topic",
 			"filterAdd": "Add filter",

--- a/views/administration/users_registrationcomplete.hbs
+++ b/views/administration/users_registrationcomplete.hbs
@@ -58,8 +58,8 @@
     </div>
 </div>
 <div class="row users-register-complete noprint">
-    <div class="modal-footer w-50">
-        <a class="btn btn-secondary" href={{linktarget}}>
+    <div class="modal-footer w-100">
+        <a class="btn btn-primary" href={{linktarget}}>
             {{submitLabel}}
         </a>
     </div>


### PR DESCRIPTION
# Description
Wording verwirrend (!!) - Please change text on one button from "Zurück" to "Fertig"

## Links to Tickets or other pull requests

- https://ticketsystem.schul-cloud.org/browse/SC-6975

## Changes
changed button text, color and position

## Screenshots of UI changes
![image](https://user-images.githubusercontent.com/40116220/102210823-f8040780-3ed2-11eb-891f-5343261336aa.png)
