### PR TITLE
Update wordlist.js

### DIFF
--- a/static/other/wordlist.js
+++ b/static/other/wordlist.js
@@ -57,7 +57,7 @@ module.exports = [
 	'saison', 'konzept', 'roman', 'auftrag', 'position', 'luft',
 	'studenten', 'ohnehin', 'verhindern', 'medien', 'verkauft', 'minister',
 	'gesamten', 'verwendet', 'vorbei', 'bezeichnet', 'vertrag', 'staatsanwaltschaft',
-	'israel', 'wissenschaftler', 'patienten', 'nutzen', 'betrieb', 'michael',
+	'wissenschaftler', 'patienten', 'nutzen', 'betrieb', 'michael',
 	'beteiligt', 'professor', 'fernsehen', 'erinnert', 'liste', 'eingesetzt',
 	'autos', 'hoffnung', 'nennt', 'bisherigen', 'erkennen', 'treffen',
 	'begonnen', 'gezeigt', 'gefordert', 'wohnung', 'hintergrund', 'selten',


### PR DESCRIPTION
removed "israel" and "isrealischen" because it lead to strange political combinations