### PR TITLE
SC-8594–drag icon on the topic card is not visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 ### Fixed
 
 - SC-8414 - Made school number field editable for LDAP schools
+- SC-8594 - make drag icon visible again
 
 ## [25.6.0] - 09.02.21
 

--- a/static/styles/courses/course.scss
+++ b/static/styles/courses/course.scss
@@ -4,7 +4,6 @@
 .move-handle {
 	cursor: move;
 	white-space: nowrap;
-	color: $colorWhite;
 }
 
 .count-badge {
@@ -449,6 +448,7 @@
 
 	.move-handle {
 		margin-right: 10px;
+		color: $colorWhite;
 	}
 
 	.right-btn-group {

--- a/static/styles/courses/course.scss
+++ b/static/styles/courses/course.scss
@@ -32,6 +32,7 @@
 	.btn-course-dropdown {
 		padding: 0;
 		background-color: white;
+		color: $primaryColor;
 		.i-cog {
 			font-size: medium;
 			color: $fontColor;
@@ -42,10 +43,6 @@
 	.course-headline {
 		display: inline-block;
 		margin-right: 10px;
-	}
-
-	.dropdown-toggle:hover {
-		color: $primaryColor !important;
 	}
 
 	.dropdown-toggle:after {

--- a/static/styles/courses/course.scss
+++ b/static/styles/courses/course.scss
@@ -4,6 +4,7 @@
 .move-handle {
 	cursor: move;
 	white-space: nowrap;
+	color: $colorWhite;
 }
 
 .count-badge {
@@ -32,13 +33,16 @@
 	.btn-course-dropdown {
 		padding: 0;
 		background-color: white;
-		color: $primaryColor;
 		.i-cog {
 			font-size: medium;
 			color: $fontColor;
 			margin-left: 10px;
 		}
 	}
+
+	.dropdown-toggle:hover {
+        color: $primaryColor !important;
+    }
 
 	.course-headline {
 		display: inline-block;

--- a/static/styles/courses/course.scss
+++ b/static/styles/courses/course.scss
@@ -40,10 +40,6 @@
 		}
 	}
 
-	.dropdown-toggle:hover {
-        color: $primaryColor !important;
-    }
-
 	.course-headline {
 		display: inline-block;
 		margin-right: 10px;


### PR DESCRIPTION
# Description
drag icon on the topic card is not visible; make it visible again

## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/SC-8594

## Changes
css - add color: $white

## Screenshots of UI changes
before 
<img width="1199" alt="Bildschirmfoto 2021-02-05 um 17 06 32" src="https://user-images.githubusercontent.com/63390574/107058212-9d04d780-67d4-11eb-8e5f-da0c80d0ce41.png">

after:
<img width="1382" alt="Bildschirmfoto 2021-02-05 um 17 02 10" src="https://user-images.githubusercontent.com/63390574/107057871-31bb0580-67d4-11eb-888f-abe02064b93b.png">

