### PR TITLE
SC-8597 – Course name title has wrong color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 ### Changed
 
 - SC-8408 - improved course update logic. Delete all events for the course before creating new
+- SC-8597 - changing color of the course headline into primary
 
 ### Added
 

--- a/static/styles/courses/course.scss
+++ b/static/styles/courses/course.scss
@@ -32,6 +32,7 @@
 	.btn-course-dropdown {
 		padding: 0;
 		background-color: white;
+		color: $primaryColor;
 		.i-cog {
 			font-size: medium;
 			color: $fontColor;
@@ -42,10 +43,6 @@
 	.course-headline {
 		display: inline-block;
 		margin-right: 10px;
-	}
-
-	.dropdown-toggle:hover {
-		color: $primaryColor !important;
 	}
 
 	.dropdown-toggle:after {


### PR DESCRIPTION
# Description
Course name title has wrong color

## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/SC-8597

## Changes
set course name title primary color

## Screenshots of UI changes
before:
<img width="1318" alt="Bildschirmfoto 2021-02-05 um 17 17 05" src="https://user-images.githubusercontent.com/63390574/107060605-77c59880-67d7-11eb-91d0-4dada48415c9.png">

after:
<img width="1317" alt="Bildschirmfoto 2021-02-05 um 17 20 54" src="https://user-images.githubusercontent.com/63390574/107060593-7300e480-67d7-11eb-9423-514b24249451.png">

