### PR TITLE
SC - 8495 remove link from footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 ### Removed
 
 - SC-6311 - Removed itslearning from available system types
+- SC-8495 - Removed the link datenschutzbeauftragter@hpi-schul-cloud.de from the footer
 
 ### Changed
 

--- a/theme/brb/views/lib/extended_footer.hbs
+++ b/theme/brb/views/lib/extended_footer.hbs
@@ -4,16 +4,20 @@
 			<div class="col-md-4">
 				<h4>{{$t "global.link.contact" }}</h4>
 				<ul>
-					<li><a href="mailto:feedback@hpi-schul-cloud.de" target="_blank" rel="noopener" aria-label="Support {{$t "global.link.openInNewTabWarning"}}">Support: <span
+					<li><a href="mailto:feedback@hpi-schul-cloud.de" target="_blank" rel="noopener" aria-label="Support {{$t "
+							global.link.openInNewTabWarning"}}">Support: <span
 								class="text-nowrap">feedback@hpi-schul-cloud.de</span></a></li>
-					<li><a href="mailto:brandenburg@hpi-schul-cloud.de" target="_blank" rel="noopener" aria-label="Allgemeine Anfragen {{$t "global.link.openInNewTabWarning"}}">Allgemeine Anfragen: <span
+					<li><a href="mailto:brandenburg@hpi-schul-cloud.de" target="_blank" rel="noopener"
+							aria-label="Allgemeine Anfragen {{$t " global.link.openInNewTabWarning"}}">Allgemeine Anfragen: <span
 								class="text-nowrap">brandenburg@hpi-schul-cloud.de</span></a></li>
-					<li><a href="mailto:inhalte@hpi-schul-cloud.de" target="_blank" rel="noopener" aria-label="Inhalteanbieter {{$t "global.link.openInNewTabWarning"}}">Inhalteanbieter: <span
+					<li><a href="mailto:inhalte@hpi-schul-cloud.de" target="_blank" rel="noopener"
+							aria-label="Inhalteanbieter {{$t " global.link.openInNewTabWarning"}}">Inhalteanbieter: <span
 								class="text-nowrap">inhalte@hpi-schul-cloud.de</span></a></li>
-                    <li><a href="mailto:datenschutz-fragen@hpi-schul-cloud.de" target="_blank" rel="noopener" aria-label="{{$t "lib.extended_footer.link.privacy" }} {{$t "global.link.openInNewTabWarning"}}">{{$t "lib.extended_footer.link.privacy" }} <span
-                                class="text-nowrap">datenschutz-fragen@hpi-schul-cloud.de</span></a></li>
-                    <li><a href="mailto:datenschutzbeauftragter@hpi-schul-cloud.de" target="_blank" rel="noopener" aria-label="{{$t "lib.extended_footer.link.privacy_responsible_person" }} {{$t "global.link.openInNewTabWarning"}}">{{$t "lib.extended_footer.link.privacy_responsible_person" }} <span
-                                class="text-nowrap">datenschutzbeauftragter@hpi-schul-cloud.de</span></a></li>
+					<li><a href="mailto:datenschutz-fragen@hpi-schul-cloud.de" target="_blank" rel="noopener" aria-label="{{$t "
+							lib.extended_footer.link.privacy" }} {{$t "global.link.openInNewTabWarning" }}">{{$t
+							"lib.extended_footer.link.privacy" }} <span
+								class="text-nowrap">datenschutz-fragen@hpi-schul-cloud.de</span></a></li>
+
 
 				</ul>
 			</div>
@@ -21,14 +25,20 @@
 				<h4>Links</h4>
 				<ul>
 					<li><a href="/impressum">{{$t "global.link.imprint" }}</a></li>
-					<li><a href="{{theme.documents.specificFiles.termsOfUseSchool}}" target="_blank" aria-label="{{$t "login.headline.onlyTermsOfUse"}} PDF {{$t "global.link.openInNewTabWarning"}}"
-							rel="noopener">{{$t "login.headline.onlyTermsOfUse"}}
+					<li><a href="{{theme.documents.specificFiles.termsOfUseSchool}}" target="_blank" aria-label="{{$t "
+							login.headline.onlyTermsOfUse"}} PDF {{$t "global.link.openInNewTabWarning" }}" rel="noopener">{{$t
+							"login.headline.onlyTermsOfUse"}}
 							Schul-Cloud Brandenburg</a></li>
-					<li><a href="{{theme.documents.specificFiles.privacyExemplary}}" target="_blank" aria-label="{{$t "global.text.dataProtection"}} Schul-Cloud Brandenburg PDF {{$t "global.link.openInNewTabWarning"}}"
+					<li><a href="{{theme.documents.specificFiles.privacyExemplary}}" target="_blank" aria-label="{{$t "
+							global.text.dataProtection"}} Schul-Cloud Brandenburg PDF {{$t "global.link.openInNewTabWarning" }}"
 							rel="noopener">{{$t "global.text.dataProtection"}}
 							Schul-Cloud Brandenburg</a></li>
-					<li><a href="https://github.com/hpi-schul-cloud/" target="_blank" rel="noopener" aria-label="{{$t "lib.global.link.github"}} {{$t "global.link.openInNewTabWarning"}}">{{$t "lib.global.link.github"}}</a></li>
-					<li><a href="https://status.schul-cloud.org" target="_blank" rel="noopener" aria-label="{{$t "lib.global.link.status"}} {{$t "global.link.openInNewTabWarning"}}">{{$t "lib.global.link.status"}}</a></li>
+					<li><a href="https://github.com/hpi-schul-cloud/" target="_blank" rel="noopener" aria-label="{{$t "
+							lib.global.link.github"}} {{$t "global.link.openInNewTabWarning" }}">{{$t "lib.global.link.github"}}</a>
+					</li>
+					<li><a href="https://status.schul-cloud.org" target="_blank" rel="noopener" aria-label="{{$t "
+							lib.global.link.status"}} {{$t "global.link.openInNewTabWarning" }}">{{$t "lib.global.link.status"}}</a>
+					</li>
 				</ul>
 			</div>
 		</div>

--- a/views/lib/extended_footer_links.hbs
+++ b/views/lib/extended_footer_links.hbs
@@ -1,11 +1,13 @@
-
-<li><a href="mailto:feedback@hpi-schul-cloud.de" target="_blank" rel="noopener" aria-label="{{$t "lib.extended_footer.link.support"}} {{$t "global.link.openInNewTabWarning"}}">{{$t "lib.extended_footer.link.support"}} <span
-			class="text-nowrap">feedback@hpi-schul-cloud.de</span></a></li>
-<li><a href="mailto:{{getConfig "SC_CONTACT_EMAIL"}}" target="_blank" rel="noopener" aria-label="{{$t "lib.extended_footer.link.generalInquiries" }} {{$t "global.link.openInNewTabWarning"}}">{{$t "lib.extended_footer.link.generalInquiries" }} <span
-			class="text-nowrap">{{getConfig "SC_CONTACT_EMAIL"}}</span></a></li>
-<li><a href="mailto:inhalte@hpi-schul-cloud.de" target="_blank" rel="noopener" aria-label="{{$t "lib.extended_footer.link.contentProviders" }} {{$t "global.link.openInNewTabWarning"}}">{{$t "lib.extended_footer.link.contentProviders" }} <span
-			class="text-nowrap">inhalte@hpi-schul-cloud.de</span></a></li>
-<li><a href="mailto:datenschutz-fragen@hpi-schul-cloud.de" target="_blank" rel="noopener" aria-label="{{$t "lib.extended_footer.link.privacy" }} {{$t "global.link.openInNewTabWarning"}}">{{$t "lib.extended_footer.link.privacy" }} <span
-			class="text-nowrap">datenschutz-fragen@hpi-schul-cloud.de</span></a></li>
-<li><a href="mailto:datenschutzbeauftragter@hpi-schul-cloud.de" target="_blank" rel="noopener" aria-label="{{$t "lib.extended_footer.link.privacy_responsible_person" }} {{$t "global.link.openInNewTabWarning"}}">{{$t "lib.extended_footer.link.privacy_responsible_person" }} <span
-			class="text-nowrap">datenschutzbeauftragter@hpi-schul-cloud.de</span></a></li>
+<li><a href="mailto:feedback@hpi-schul-cloud.de" target="_blank" rel="noopener" aria-label="{{$t "
+		lib.extended_footer.link.support"}} {{$t "global.link.openInNewTabWarning" }}">{{$t
+		"lib.extended_footer.link.support"}} <span class="text-nowrap">feedback@hpi-schul-cloud.de</span></a></li>
+<li><a href="mailto:mailto:feedback@hpi-schul-cloud.de" target="_blank" rel="noopener" aria-label="{{$t "
+		lib.extended_footer.link.generalInquiries" }} {{$t "global.link.openInNewTabWarning" }}">{{$t
+		"lib.extended_footer.link.generalInquiries" }} <span class="text-nowrap">feedback@hpi-schul-cloud.de</span></a></li>
+<li><a href="mailto:inhalte@hpi-schul-cloud.de" target="_blank" rel="noopener" aria-label="{{$t "
+		lib.extended_footer.link.contentProviders" }} {{$t "global.link.openInNewTabWarning" }}">{{$t
+		"lib.extended_footer.link.contentProviders" }} <span class="text-nowrap">inhalte@hpi-schul-cloud.de</span></a></li>
+<li><a href="mailto:datenschutz-fragen@hpi-schul-cloud.de" target="_blank" rel="noopener" aria-label="{{$t "
+		lib.extended_footer.link.privacy" }} {{$t "global.link.openInNewTabWarning" }}">{{$t
+		"lib.extended_footer.link.privacy" }} <span class="text-nowrap">datenschutz-fragen@hpi-schul-cloud.de</span></a>
+</li>


### PR DESCRIPTION
# Description

Removed the link datenschutzbeauftragter@hpi-schul-cloud.de from the Footer in HPI Schul-Cloud
Schul-Cloud Brandenburg and HPI Schul-Cloud International

- https://ticketsystem.schul-cloud.org/browse/SC-8495

before:
<img width="433" alt="Screenshot 2021-02-08 at 13 37 28" src="https://user-images.githubusercontent.com/23704397/107221817-6e753f80-6a14-11eb-8059-d77a456faece.png">

after:
<img width="385" alt="Screenshot 2021-02-08 at 13 49 57" src="https://user-images.githubusercontent.com/23704397/107221933-92d11c00-6a14-11eb-8b79-a8afd0b1c6fe.png">

## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
