### PR TITLE
SC - 8565 long text not wrapping

### DIFF
--- a/views/courses/course.hbs
+++ b/views/courses/course.hbs
@@ -7,8 +7,10 @@
 {{/content}}
 
 {{#content "scripts" mode="append"}}
-<script src="{{getAssetPath '/scripts/jquery/jquery-ui.min.js'}}" type="text/javascript" nonce="{{nonceValue}}" defer></script>
-<script src="{{getAssetPath '/scripts/jquery/jquery.ui.touch-punch.js'}}" type="text/javascript" nonce="{{nonceValue}}" defer></script>
+<script src="{{getAssetPath '/scripts/jquery/jquery-ui.min.js'}}" type="text/javascript" nonce="{{nonceValue}}"
+  defer></script>
+<script src="{{getAssetPath '/scripts/jquery/jquery.ui.touch-punch.js'}}" type="text/javascript" nonce="{{nonceValue}}"
+  defer></script>
 <script src="{{getAssetPath '/scripts/courses.js'}}" type="text/javascript" nonce="{{nonceValue}}" defer></script>
 <script src="{{getAssetPath '/scripts/topic.js'}}" type="text/javascript" nonce="{{nonceValue}}" defer></script>
 <script src="{{getAssetPath '/scripts/tabbar.js'}}" type="text/javascript" nonce="{{nonceValue}}" defer></script>
@@ -18,8 +20,9 @@
 <meta name="baseUrl" content={{baseUrl}}>
 <div class="dropdown dropdown-course minimal-button">
   {{#inArray "COURSE_EDIT" scopedCoursePermission}}
-  <button class="btn btn-sm dropdown-toggle btn-course-dropdown" title="{{$t "global.label.more"}}" data-toggle="dropdown">
-    <h1 class="h4" id="page-title" class="course-headline">
+  <button class="btn btn-sm dropdown-toggle btn-course-dropdown" title="{{$t " global.label.more"}}"
+    data-toggle="dropdown">
+    <h1 style="white-space: normal;" class="h4" id="page-title" class="course-headline">
       {{{stripOnlyScript ../name}}}
       <i class="fa fa-ellipsis-v i-cog" aria-hidden="true"></i>
       {{#if ../isArchived}}<small class="count-badge" data-badge="Archiv" /></small>{{/if}}
@@ -54,9 +57,9 @@
     <p class="lead">{{$t "courses._course.text.courseDescription"}} {{{stripOnlyScript description}}}</p>
     {{/if}}
     {{#unless ../isArchived}}
-        {{#if nextEvent}}
+    {{#if nextEvent}}
     <p class="text-muted">{{$t "courses._course.text.nextClass"}} {{i18nDateTime nextEvent}}</p>
-        {{/if}}
+    {{/if}}
     {{/unless}}
     <a href="{{filesUrl}}" class="btn btn-add btn-secondary pull-right">
       <i class="fa fa-folder-open" aria-hidden="true"></i>

--- a/views/lib/components/sc-card.hbs
+++ b/views/lib/components/sc-card.hbs
@@ -1,9 +1,10 @@
 {{#if this.url}}
-    <article class="sc-card locationlink" data-loclink="{{this.url}}">
+<article class="sc-card locationlink" data-loclink="{{this.url}}">
     {{else}}
     <article class="sc-card">
         {{/if}}
-        <div class="sc-card-header" data-testid="header-of-element" {{#if this.background}} style="background:{{this.background}};" {{/if}}>
+        <div class="sc-card-header" data-testid="header-of-element" {{#if this.background}}
+            style="background:{{this.background}};" {{/if}}>
             {{#if this.isRSS}}
             {{#userHasPermission "SCHOOL_NEWS_EDIT"}}
             <span class="rss-icon">RSS</span>
@@ -11,7 +12,8 @@
             {{/if}}
             <span class="sc-card-title">
                 <div>
-                    <span class="title" data-testid="title_of_an_element">{{{ stripOnlyScript this.title }}}</span>
+                    <span style="white-space: normal;" class="title" data-testid="title_of_an_element">{{{
+                        stripOnlyScript this.title }}}</span>
                 </div>
                 {{#if this.target.name}}
                 <div class="tag tag-default">{{this.target.name}}</div>
@@ -32,8 +34,8 @@
                     <i class="fa fa-{{this.icon}}"></i>
                 </a>
                 {{else}}
-                    <a href="{{this.link}}" class="sc-card-menu-action {{this.class}}" target="_blank"
-                        alt="'{{../../title}}' {{this.alt}}.">
+                <a href="{{this.link}}" class="sc-card-menu-action {{this.class}}" target="_blank"
+                    alt="'{{../../title}}' {{this.alt}}.">
                     <i class="fa fa-{{this.icon}}"></i>
                 </a>
                 {{/if}}
@@ -49,18 +51,13 @@
         </div>
         <div class="sc-card-footer">
             {{#if additionalInfoName}}
-                <div class="additionalInfo">
-                    {{> (concat 'lib/sc-card_additionalInfo/' additionalInfoName title=this.title) }}
-                </div>
+            <div class="additionalInfo">
+                {{> (concat 'lib/sc-card_additionalInfo/' additionalInfoName title=this.title) }}
+            </div>
             {{/if}}
-            <a href="{{url}}" 
-                {{#if link-aria-label}}
-                    aria-label="{{link-aria-label}}"
-                {{else}}
-                    aria-label="{{{link-text}}}"
-                {{/if}}
-                rel="canonical">
-                    {{{link-text}}}
+            <a href="{{url}}" {{#if link-aria-label}} aria-label="{{link-aria-label}}" {{else}}
+                aria-label="{{{link-text}}}" {{/if}} rel="canonical">
+                {{{link-text}}}
             </a>
         </div>
     </article>


### PR DESCRIPTION
# Description

In the teams and courses cards, the text does't wrap, but rather has an overflow:hidden effect. I added a white-space property to wrap it on the next line.

- https://ticketsystem.schul-cloud.org/browse/SC-8565


## Screenshots of UI changes
before:
<img width="341" alt="Screenshot 2021-02-10 at 10 51 41" src="https://user-images.githubusercontent.com/23704397/107617048-7b31a780-6c4f-11eb-99cd-a41199125a31.png">

after:
<img width="317" alt="Screenshot 2021-02-10 at 10 51 48" src="https://user-images.githubusercontent.com/23704397/107617061-7ec52e80-6c4f-11eb-9a26-9d35c3c15712.png">

## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
