### PR TITLE
Feature/SC-8914: Add script for post message when click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ## Unreleased
 
+## Changed
+
+- SC-8914 - oauth2: add post message call on depseudonymized iframes to handle clicks
+
 ## [26.1.0]
 
 ## [26.0.4] - 2021-03-24

--- a/views/oauth2/username.hbs
+++ b/views/oauth2/username.hbs
@@ -10,6 +10,16 @@
         {{#ifeq depseudonymized false}}
             <script src="{{getAssetPath '/scripts/oauth2.js'}}" type="text/javascript" nonce="{{nonceValue}}"></script>
             <style>.depseudo{cursor:pointer;}</style>
+        {{else}}
+             <script>
+                 $(() => {
+                     $(document).on('click', () => {
+                         window.parent.postMessage({
+                             pseudonym: document.URL.substring(document.URL.lastIndexOf('/') + 1),
+                         }, '*');
+                     });
+                 });
+             </script>
         {{/ifeq}}
     {{/block}}
 </head>


### PR DESCRIPTION
# Description
Some depseudonymization iframes serve as real clickable buttons. Therefore, OAuth2 provider like bettermarks would like to be informed via the postMessage API about a click on the iframe if it is already depseudonymized.

## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/SC-8914

## Changes
When a depseudonymized iframe is clicked a postMessage Call is made to propagate the click to the page that embeds the iframe.

## Data Security <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>
Only the pseudonym is propagated.

## Deployment
No changes here.

## New Repos, NPM packages or vendor scripts
No changes here.

## Screenshots of UI changes
No changes here.

## Approval for review
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
