### PR TITLE
[OPS-2445] change Docker login to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ branches:
   only:
     - develop
     - master
-    - /^(?i:release).*$/
+    - /^(release).*$/
     # naming convention feature/<JIRA-Ticket ID>-<Jira_Summary>
-    - /^((hotfix|feature)\/[A-Z]+-[0-9]+-[a-zA-Z_]+)$/
+    - /^((hotfix|feature)\/[A-Z]+-[0-9]+-[a-zA-Z0-9_]+)$/
 services:
   - docker
 env:
@@ -20,7 +20,7 @@ env:
     - LERNSTORE_MODE=LEGACY
 stages:
   - name: Test
-    if: NOT (commit_message =~ /(skip-test-stage)/ ) OR branch = master
+    if: NOT ( (commit_message =~ /(skip-test-stage)/ ) OR branch = master OR branch = develop OR branch = /^(feature).*$/ AND "$TRAVIS_PULL_REQUEST" != "false" )
   - name: Build
     if: NOT (commit_message =~ /(skip-build-stage)/)
   - name: Deploy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Changed
 
+- OPS-2445 - change Docker login to build
 - SC-8440 - fix manual consent for class
 - SC-6950 - validation for officialSchoolNumber now allows 6 digits instead of 5
 - SC-8668 - fixed small typo in manage school page

--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ then
   #export DOCKERTAG=latest
   export DOCKERTAG="release_v$( jq -r '.version' package.json )_latest"
   export DOCKERTAG_SHA="release_v$( jq -r '.version' package.json )_$GIT_SHA"
-elif [[ "$TRAVIS_BRANCH" =~ ^feature\/[A-Z]+-[0-9]+-[a-zA-Z_]+$ ]]
+elif [[ "$TRAVIS_BRANCH" =~ ^feature\/[A-Z]+-[0-9]+-[a-zA-Z0-9_]+$ ]]
 then
 	# extract JIRA_TICKET_ID from TRAVIS_BRANCH
 	JIRA_TICKET_ID=${TRAVIS_BRANCH/#feature\//}
@@ -35,7 +35,7 @@ then
 	# export DOCKERTAG=naming convention feature-<Jira id>-latest
 	export DOCKERTAG="feature_${JIRA_TICKET_ID}_latest"
   export DOCKERTAG_SHA="feature_${JIRA_TICKET_ID}_$GIT_SHA"
-elif  [[ "$TRAVIS_BRANCH" =~ ^hotfix\/[A-Z]+-[0-9]+-[a-zA-Z_]+$ ]]
+elif  [[ "$TRAVIS_BRANCH" =~ ^hotfix\/[A-Z]+-[0-9]+-[a-zA-Z0-9_]+$ ]]
 then
   	# extract JIRA_TICKET_ID from TRAVIS_BRANCH
 	JIRA_TICKET_ID=${TRAVIS_BRANCH/#hotfix\//}
@@ -58,11 +58,11 @@ echo "DOCKERTAG: $DOCKERTAG"
 echo "DOCKERTAG_SHA: $DOCKERTAG_SHA"
 
 function buildandpush {
-  # build container default theme
-  docker build -t schulcloud/schulcloud-client:"$DOCKERTAG" -t schulcloud/schulcloud-client:"$DOCKERTAG_SHA" .
-
   # Log in to the docker CLI
   echo "$MY_DOCKER_PASSWORD" | docker login -u "$DOCKER_ID" --password-stdin
+  
+  # build container default theme
+  docker build -t schulcloud/schulcloud-client:"$DOCKERTAG" -t schulcloud/schulcloud-client:"$DOCKERTAG_SHA" .
 
   # take those images and push them up to docker hub
   docker push schulcloud/schulcloud-client:"$DOCKERTAG"


### PR DESCRIPTION
# Description
Change buildpipelines (Server, Client, Nuxt) to execute E2E tests according QF decision

## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/OPS-2418
Execution of E2E test during builds
https://docs.hpi-schul-cloud.org/display/TSC/Deployment+to+test%2C+staging+and+hotfix

## Changes
condition on travis and build.sh

## Data Security <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>
none

## Deployment
none

## New Repos, NPM packages or vendor scripts
none

## Screenshots of UI changes
none

## Approval for review
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
