### PR TITLE
BC-1302 - set the default docker registry for all, will be overwritten for develop

### DIFF
--- a/ansible/group_vars/all/schulcloud-client.yml
+++ b/ansible/group_vars/all/schulcloud-client.yml
@@ -1,3 +1,4 @@
 ---
 CLIENT_PORT: 3100
+SCHULCLOUD_CLIENT_IMAGE: schulcloud/schulcloud-client
 

--- a/ansible/group_vars/reference/schulcloud-client.yml
+++ b/ansible/group_vars/reference/schulcloud-client.yml
@@ -1,2 +1,0 @@
----
-SCHULCLOUD_CLIENT_IMAGE: schulcloud/schulcloud-client


### PR DESCRIPTION
# Description
Set the ansible variabel SCHULCLOUD_CLIENT_IMAGE will be set default to the schulcloud/schulcloud-client as docker regestry.
It will be overwritten by the value from ansible/group_vars/develop/schulcloud-client.yml for the develop instances

## Links to Tickets or other pull requests
hpi-schul-cloud/schulcloud-server#3321
hpi-schul-cloud/nuxt-client#2051
hpi-schul-cloud/schulcloud-calendar#112
hpi-schul-cloud/superhero-dashboard#161
hpi-schul-cloud/antivirus_check_service#22
https://ticketsystem.hpi-schul-cloud.org/browse/BC-1302

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.