### PR TITLE
Pin self developted nexboard-api-js to version 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
 		"multer": "^1.3.0",
 		"multi-download": "^3.0.0",
 		"natives": "^1.1.6",
-		"nexboard-api-js": "git+https://github.com/schul-cloud/nexboard-api-js.git",
+		"nexboard-api-js": "git+https://github.com/schul-cloud/nexboard-api-js.git#1.1.2",
 		"oauth-1.0a": "^2.1.0",
 		"path.join": "^1.0.0",
 		"postcss-loader": "^3.0.0",


### PR DESCRIPTION
# Description
For work on the nexboard-api-js repository the used version is pinned to Version 1.1.2
Later planned to release new versions on https://www.npmjs.com/package/nexboard-api-js

## Links to Tickets or other pull requests
<!--
Base links to copy
- https://github.com/schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.schul-cloud.org/browse/SC-????
-->

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Data Security <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM packages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes
<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
