### PR TITLE
BC-1667 - remove auto reviewer assignment by pullapprove

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -17,11 +17,3 @@ notifications:
 - when: pullapprove.approved
   if: "author_association == 'CONTRIBUTOR'"
   comment: "The review is completed. Thanks @{{ author }}, we'll take it from here."
-
-groups:
-  general:
-    reviewers:
-      teams:
-      - general
-    reviews:
-      required: 1  # number of approvals required from this group


### PR DESCRIPTION
# Description
BC-1667 - remove auto reviewer assignment by pullapprove

## Links to Tickets or other pull requests
hpi-schul-cloud/schulcloud-server#3423
hpi-schul-cloud/end-to-end-tests#412
hpi-schul-cloud/nuxt-client#2140

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.dbildungscloud.de/pages/viewpage.action?pageId=92831762)
