### PR TITLE
BC-1695 - Removing 'git add' from lint-staged config

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,6 +1,5 @@
 module.exports = {
 	'static/images/**/*.{png,jpeg,jpg,gif,svg}': [
 		'imagemin-lint-staged',
-		'git add',
 	],
 };


### PR DESCRIPTION
# Description
After using "git add" and "git commit" the message "some of your tasks use git add command. Please remove it from the config since all modifications made by tasks will be automatically added to the git commit index." is displayed.

## Links to Tickets or other pull requests
Ticket: https://ticketsystem.dbildungscloud.de/browse/BC-1695

## Changes
Removing 'git add' from the lint-staged.config.js
According to https://github.com/okonet/lint-staged/issues/775 it's not necessary  anymore.

## Data Security <sub><sup>details [on Confluence](https://docs.dbildungscloud.de/x/2S3GBg)</sup></sub>

## Deployment

## New Repos, NPM packages or vendor scripts

## Screenshots of UI changes

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definition of Done
More and detailed information on the *definition of done* can be found [on Confluence](https://docs.dbildungscloud.de/pages/viewpage.action?pageId=92831762)
