### PR TITLE
BC-2168 - Hide dropdowns for course/team in appointment creation

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -757,12 +757,6 @@
 		}
 	},
 	"calendar": {
-		"button": {
-			"availableCourses": "Verfügbare Kurse",
-			"availableTeams": "Verfügbare Teams",
-			"chooseACourse": "Wähle einen Kurs...",
-			"chooseATeam": "Wähle ein Team"
-		},
 		"headline": {
 			"calendar": "Kalender"
 		},
@@ -772,8 +766,6 @@
 		},
 		"label": {
 			"addVideoConference": "Videokonferenz hinzufügen?",
-			"createForCourse": "Für Kurs anlegen?",
-			"createForTeam": "Für Team anlegen?",
 			"location": "Ort"
 		},
 		"text": {
@@ -821,7 +813,6 @@
 		},
 		"form_add_lesson": {
 			"label": {
-				"chooseACourse": "Wähle einen Kurs / Fach",
 				"chooseALessonTopic": "Wähle ein Unterrichtsthema"
 			}
 		},

--- a/locales/en.json
+++ b/locales/en.json
@@ -757,12 +757,6 @@
 		}
 	},
 	"calendar": {
-		"button": {
-			"availableCourses": "Available courses",
-			"availableTeams": "Available teams",
-			"chooseACourse": "Pick a course...",
-			"chooseATeam": "Choose a team"
-		},
 		"headline": {
 			"calendar": "Calendar"
 		},
@@ -772,8 +766,6 @@
 		},
 		"label": {
 			"addVideoConference": "Add a videoconference?",
-			"createForCourse": "Create for course?",
-			"createForTeam": "Create for team?",
 			"location": "Place"
 		},
 		"text": {
@@ -821,7 +813,6 @@
 		},
 		"form_add_lesson": {
 			"label": {
-				"chooseACourse": "Choose a course / subject",
 				"chooseALessonTopic": "Choose a lesson topic"
 			}
 		},

--- a/locales/es.json
+++ b/locales/es.json
@@ -757,12 +757,6 @@
 		}
 	},
 	"calendar": {
-		"button": {
-			"availableCourses": "Cursos disponibles",
-			"availableTeams": "Equipos disponibles",
-			"chooseACourse": "Elegir un curso...",
-			"chooseATeam": "Elegir un equipo"
-		},
 		"headline": {
 			"calendar": "Calendario"
 		},
@@ -772,8 +766,6 @@
 		},
 		"label": {
 			"addVideoConference": "¿Añadir una videoconferencia?",
-			"createForCourse": "¿Crear para el curso?",
-			"createForTeam": "¿Crear para el equipo?",
 			"location": "Lugar"
 		},
 		"text": {
@@ -821,7 +813,6 @@
 		},
 		"form_add_lesson": {
 			"label": {
-				"chooseACourse": "Elige un curso / asignatura",
 				"chooseALessonTopic": "Elige un tema de la lección"
 			}
 		},

--- a/locales/ua.json
+++ b/locales/ua.json
@@ -1284,16 +1284,8 @@
 		}
 	},
 	"calendar": {
-		"button": {
-			"chooseACourse": "Виберіть курс...",
-			"chooseATeam": "Виберіть команду",
-			"availableCourses": "Наявні курси",
-			"availableTeams": "Наявні команди"
-		},
 		"label": {
 			"addVideoConference": "Додати відеоконференцію?",
-			"createForCourse": "Створити для курсу?",
-			"createForTeam": "Створити для команди?",
 			"location": "Місце"
 		},
 		"text": {
@@ -1316,7 +1308,6 @@
 		},
 		"form_add_lesson": {
 			"label": {
-				"chooseACourse": "Вибрати курс / предмет",
 				"chooseALessonTopic": "Вибрати тему уроку"
 			}
 		},

--- a/views/calendar/forms/form-create-event.hbs
+++ b/views/calendar/forms/form-create-event.hbs
@@ -15,45 +15,6 @@
     <label class="control-label" for="location">{{$t "calendar.label.location" }}</label>
     <input id="location" data-testid="team_event_location" class="form-control" name="location" placeholder="{{$t "calendar.input.egGym"}}">
 </div>
-{{#if addCourse}}
-    {{#userHasPermission "COURSE_EDIT"}}
-    <div class="form-group create-course-event">
-        <div class="checkbox disabled">
-            <input id="toggle{{../collapseIdCourse}}" name="isCourseEvent" type="checkbox" data-Ref="{{../collapseIdCourse}}"  data-toggle="toggle" data-defauttext="{{$t "calendar.button.chooseACourse" }}" data-on="{{$t "global.button.yes"}}" data-off="{{$t "global.button.no"}}">
-            <label for="toggle{{../collapseIdCourse}}">
-               {{$t "calendar.label.createForCourse" }}
-            </label>
-        </div>
-        <div id="collapse{{../collapseIdCourse}}" class="panel-collapse collapse">
-            <div class="form-group">
-            <label for="calendarCourseSelection">{{$t "calendar.button.availableCourses" }}</label>
-                <select aria-label="{{$t "calendar.label.createForCourse" }}" id="selection{{../collapseIdCourse}}" class="form-control" name="calendarCourseSelection"></select>
-            </div>
-        </div>
-    </div>
-    {{/userHasPermission}}
-{{/if}}
-
-{{#if addTeam}}
-    {{#userHasPermission "TEAM_EDIT"}}
-    <div class="form-group create-team-event">
-        <div class="checkbox disabled">
-            <input id="toggle{{../collapseIdTeam}}" name="isTeamEvent" type="checkbox" data-Ref="{{../collapseIdTeam}}" data-toggle="toggle" data-defauttext="{{$t "calendar.button.chooseATeam" }}" data-on="{{$t "global.button.yes"}}" data-off="{{$t "global.button.no"}}">
-            <label for="toggle{{../collapseIdTeam}}">
-               {{$t "calendar.label.createForTeam" }}
-            </label>
-        </div>
-        <div id="collapse{{../collapseIdTeam}}" class="panel-collapse collapse">
-            <div class="form-group">
-                <label for="calendarTeamSelection">{{$t "calendar.button.availableTeams" }}</label>
-                <select aria-label="{{$t "calendar.label.createForTeam" }}" id="selection{{../collapseIdTeam}}" class="form-control" name="calendarTeamSelection"></select>
-            </div>
-        </div>
-    </div>
-    {{/userHasPermission}}
-{{/if}}
-
-
 {{#ifConfig "FEATURE_VIDEOCONFERENCE_ENABLED" true}}
     {{#if ../showVideoconferenceOption}}
     <div class="form-group create-videoconference hidden">


### PR DESCRIPTION
# Description
<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and end-to-end-tests), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->
As a user I don't want to see the options for courses and teams on creating an appointment inside the calendar, because the creation of course and team-appointments doesn't work from the calendar.
## Links to Tickets or other pull requests
<!--
Base links to copy
- https://github.com/schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->
BC-2168
## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Data Security
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM packages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes
<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
