### PR TITLE
BC-2092 – delete copy button task detail view

### DIFF
--- a/controllers/homework.js
+++ b/controllers/homework.js
@@ -44,12 +44,6 @@ const getActions = (res, item, path) => [{
 	title: res.$t('homework.button.editSubmissionFromList'),
 },
 {
-	link: `${path + item._id}/copy`,
-	class: 'btn-copy',
-	icon: 'copy',
-	title: res.$t('homework.button.copySubmissionFromList'),
-},
-{
 	link: path + item._id,
 	class: 'btn-delete',
 	icon: 'trash-o',

--- a/views/homework/extended.hbs
+++ b/views/homework/extended.hbs
@@ -30,8 +30,6 @@
 						data-method="DELETE" data-name="{{../title}}" alt="{{$t "homework._task.label.deleteTaskAlt" (dict "title" ../title)}}">
 						<i class='fa fa-trash-o'></i> {{$t "global.headline.delete" }}
 					</a>
-					<a class="btn btn-secondary btn-copy" data-toggle="tooltip" title="{{$t "homework._task.label.copyTask"}}" href="{{@root.copyServiceUrl}}"
-						alt="{{$t "homework._task.label.copyTaskAlt" (dict "title" ../title)}}"> <i class='fa fa-copy'></i> {{$t "homework.button.copy" }} </a>
 				{{/userHasPermission}}
 			{{/if}}
 


### PR DESCRIPTION
# Description
delete the copy button on the task detail view on legacy

## Links to Tickets or other pull requests
https://ticketsystem.dbildungscloud.de/browse/BC-2092

## Changes
no copy-button

## Data Security
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM packages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes
<img width="897" alt="image" src="https://user-images.githubusercontent.com/63390574/179777037-21abdcd1-f48a-4614-9f7d-3763afc8fd9d.png">

## Approval for review

- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
