### PR TITLE
BC-2932-Fix sidebar(navigation) jumping

### DIFF
--- a/static/styles/lib/loggedin.scss
+++ b/static/styles/lib/loggedin.scss
@@ -264,7 +264,6 @@ aside.nav-sidebar {
 				i.fa {
 					font-size: 20px;
 					width: 25px;
-					margin-right: 6px;
 					display: inline-block;
 					text-align: center;
 					vertical-align: middle;
@@ -287,6 +286,7 @@ aside.nav-sidebar {
 					display: inline-block;
 					text-transform: uppercase;
 					text-decoration: none;
+					margin-left: 6px;
 
 					@include media-breakpoint-down(md) {
 						display: none;

--- a/static/styles/lib/loggedin.scss
+++ b/static/styles/lib/loggedin.scss
@@ -277,7 +277,6 @@ aside.nav-sidebar {
 				svg {
 					font-size: 20px;
 					width: 25px;
-					margin-right: 6px;
 					display: inline-block;
 					text-align: center;
 					vertical-align: middle;

--- a/static/styles/lib/loggedin.scss
+++ b/static/styles/lib/loggedin.scss
@@ -203,7 +203,7 @@ aside.nav-sidebar {
 				height: 60px;
 				color: $secondaryColor;
 				fill:$secondaryColor;
-				padding: 0px 5px;
+				padding: 0px 20px;
 				font-size: 16px;
 				text-decoration: none;
 				overflow-x: visible;


### PR DESCRIPTION
# Description
Fixes an error with CSS styles. When the user switches tabs in the navigation bar, the tab jumps.  When switching to the courses tab and other navigation tabs, the tabs also jump. Added indents to prevent sidebar jumps when switching navigation tabs.

## Links to Tickets or other pull requests
<!--
Base links to copy
- https://ticketsystem.dbildungscloud.de/browse/BC-2932
-->

## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Data Security
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should include following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM packages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

![2932](https://user-images.githubusercontent.com/118526182/210558982-99ec3549-3f15-499e-bade-3f4d1e595750.gif)


## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
