### PR TITLE
BC-3072 - News tab headers not showing up in mobile view

### DIFF
--- a/static/styles/lib/tabbar/tabbar.scss
+++ b/static/styles/lib/tabbar/tabbar.scss
@@ -37,10 +37,19 @@
 				vertical-align: middle;
 				cursor: pointer;
 			}
+			svg {
+				color: $secondaryColor;
+				vertical-align: middle;
+				cursor: pointer;
+			}
 			&.active .text,
 			&.active i.fa,
 			&:hover {
 				color: $primaryColor;
+				text-decoration: none;
+			}
+			&.active svg {
+				fill: $primaryColor;
 				text-decoration: none;
 			}
 		}

--- a/static/styles/lib/tabbar/tabbar.scss
+++ b/static/styles/lib/tabbar/tabbar.scss
@@ -40,7 +40,11 @@
 			svg {
 				color: $secondaryColor;
 				vertical-align: middle;
+				margin-right: 12px;
 				cursor: pointer;
+				@include media-breakpoint-down(xs) {
+					margin-right: unset;
+				}
 			}
 			&.active .text,
 			&.active i.fa,

--- a/views/news/overview.hbs
+++ b/views/news/overview.hbs
@@ -10,9 +10,26 @@
     <div class="tabContainer">
         <div class="tabs" data-max-width="1024">
             <button class="tab active" data-tab="a">
+                <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve" height="24px" width="24px">
+                <style type="text/css">
+                    .st0{fill-rule:evenodd;clip-rule:evenodd;}
+                </style>
+                <g>
+                    <path d="M12,15.5c1.8,0,3.5-1.5,3.5-3.3S14,8.9,12,8.9c-1.8,0-3.5,1.5-3.5,3.3S10.2,15.5,12,15.5z"/>
+                    <path class="st0" d="M12,5.3c4.9,0,9.2,2.8,11.4,6.7c-2.1,3.9-6.4,6.7-11.4,6.7S2.8,15.9,0.6,12C2.8,8.1,7.1,5.3,12,5.3z M12,17.1
+                        c-3.9,0-7.4-2-9.4-5.1c2-3,5.4-4.9,9.4-4.9s7.4,2,9.4,5.1C19.4,15.1,15.9,17.1,12,17.1z"/>
+                </g>
+                </svg>
                 <span class="text">{{$t "news.text.released" }}</span>
             </button>
             <button class="tab" data-tab="b">
+                <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve" height="24px" width="24px">
+                <g>
+                    <path d="M20.3,9.9c0.9-0.9,1.5-2,2.1-3.1h-1.8c-2,3.1-5.2,5-8.7,5s-6.9-2-8.7-5H1.4C2,7.9,2.7,8.9,3.5,9.9l-2.4,2.6l1.1,1.2
+                        l2.6-2.8c1.1,0.9,2.3,1.5,3.7,2l-1.1,3.8l1.5,0.5l0.9-3.8c0.8,0.2,1.4,0.2,2.1,0.2c0.8,0,1.4,0,2.1-0.2l0.9,3.8l1.5-0.5l-0.9-3.8
+                        c1.4-0.5,2.6-1.2,3.7-2l2.6,2.8l1.1-1.2L20.3,9.9L20.3,9.9z"/>
+                </g>
+                </svg>
                 <span class="text">{{$t "news.text.unpublished" }}<span class="count-badge"
                         data-badge="{{unpublishedNews.total}}" /></span></span>
             </button>


### PR DESCRIPTION
# Description
currently when the news section is opened in mobile, it does not show the two headers (once future news are present) as the icons are not implemented
<!--
  This is a template to add as much information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and end-to-end-tests), also for error cases
    - Business logic should be implemented in the API; never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
<!--
Base links to copy
- https://github.com/schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->
BC-3072
## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Data Security
<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data security team.
-->

## Deployment
<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should include following information:
  - What is required for deployment?
  - Environment variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM packages or vendor scripts
<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes
<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->
*Desktop*
![image](https://user-images.githubusercontent.com/55735359/215458520-fff2eed5-fb99-4574-a1bd-c5e0fb07866a.png)

*Mobile*
![image](https://user-images.githubusercontent.com/55735359/215458625-7184fb12-d011-42fc-890e-2895693d16cc.png)


## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
