### PR TITLE
BC-5749 - Missing pop-up for new release notes

### DIFF
--- a/controllers/dashboard.js
+++ b/controllers/dashboard.js
@@ -230,7 +230,7 @@ router.get('/', (req, res, next) => {
 			qs: {
 				$limit: 1,
 				$sort: {
-					createdAt: -1,
+					publishedAt: -1,
 				},
 			},
 		})
@@ -262,7 +262,7 @@ router.get('/', (req, res, next) => {
 			const newestRelease = newestReleases[0] || {};
 			const newRelease = !!(
 				Date.parse(userPreferences.releaseDate)
-				< Date.parse(newestRelease.createdAt)
+				< Date.parse(newestRelease.publishedAt)
 			);
 			const roles = user.roles.map((role) => role.name);
 			let homeworksFeedbackRequired = [];
@@ -278,7 +278,7 @@ router.get('/', (req, res, next) => {
 			if (newRelease || !userPreferences.releaseDate) {
 				api(req)
 					.patch(`/users/${user._id}`, {
-						json: { 'preferences.releaseDate': newestRelease.createdAt },
+						json: { 'preferences.releaseDate': newestRelease.publishedAt },
 					})
 					.catch(() => {
 						warn('failed to update user preference releaseDate');


### PR DESCRIPTION
# Description

After the fetching of new release notes, a pop-up with animated presents notifies users about the presence of new release notes. This pop-up is missing!

**Reason is**, that currently the _createdAt_ (for determing the newest release) was taken by the most recent merged commit. As for the new repo there are no commits after the initial ones and hence the createdAt value is always the old one and so no new releases are shown. Now the _publishedAt_ date is taken as determing value as this is changed with the new repo everytime a new release is done.
<!--
  This is a template to add as much information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and end-to-end-tests), also for error cases
    - Business logic should be implemented in the API; never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
<!--
Base links to copy
- https://github.com/schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->
BC-5749
## Changes
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->
- determine new release by **publishedAt** instead of **createdAt**

<img width="1393" alt="grafik" src="https://github.com/hpi-schul-cloud/schulcloud-client/assets/55735359/db635dd1-6f43-420d-8e90-5d0fc4d8274d">

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
