### PR TITLE
BC-7700 BC-7701 BC-7702 - replacing LC links on platform

### DIFF
--- a/config/default.schema.json
+++ b/config/default.schema.json
@@ -388,6 +388,10 @@
 			"default": "lernen.cloud@dataport.de",
 			"description": "Email to report accessibility issue"
 		},
+		"TRAINING_URL": {
+			"type": "string",
+			"description": "URL for the platform training material"
+		},
 		"I18N": {
 			"type": "object",
 			"description": "Configuration of I18N",

--- a/config/default.schema.json
+++ b/config/default.schema.json
@@ -385,7 +385,7 @@
 		},
 		"ACCESSIBILITY_REPORT_EMAIL": {
 			"type": "string",
-			"default": "lernen.cloud@dataport.de",
+			"default": "dbildungscloud@dataport.de",
 			"description": "Email to report accessibility issue"
 		},
 		"TRAINING_URL": {

--- a/config/default.schema.json
+++ b/config/default.schema.json
@@ -390,6 +390,7 @@
 		},
 		"TRAINING_URL": {
 			"type": "string",
+			"default": "https://lernen.dbildungscloud.de",
 			"description": "URL for the platform training material"
 		},
 		"I18N": {

--- a/helpers/handlebars/middleware.js
+++ b/helpers/handlebars/middleware.js
@@ -355,6 +355,7 @@ module.exports = (req, res, next) => {
 		});
 	}
 	// helpArea view
+	const trainingUrl = Configuration.get('TRAINING_URL');
 	res.locals.sidebarItems.push({
 		name: res.$t('global.link.helpArea'),
 		testId: 'Hilfebereich',
@@ -378,7 +379,7 @@ module.exports = (req, res, next) => {
 				name: res.$t('lib.help_menu.link.training'),
 				testId: 'Fortbildungen',
 				icon: 'file-certificate-outline',
-				link: 'https://lernen.cloud/',
+				link: trainingUrl,
 				isExternalLink: true,
 			},
 		],

--- a/theme/thr/views/about/about.hbs
+++ b/theme/thr/views/about/about.hbs
@@ -175,7 +175,7 @@
 			zusammen mit der <a
 				href="https://www.philso.uni-augsburg.de/lehrstuehle/schulpaed/Projekte/Digitalisierung/Lernen-4_0-in-der-Praxis/"
 				target="_blank">Universität Augsburg</a>
-			einen MOOC zu dem Thema <a href="https://lernen.cloud/" target="_blank">Lernen 4.0 -
+			einen MOOC zu dem Thema <a href="https://www.schulportal-thueringen.de/tio" target="_blank">Lernen 4.0 -
 				Möglichkeiten und Grenzen einer Digitalisierung im Bildungsbereich</a> durchgeführt.</p>
 		<br />
 		<div class="embed-pdf">

--- a/theme/thr/views/about/about.hbs
+++ b/theme/thr/views/about/about.hbs
@@ -175,7 +175,7 @@
 			zusammen mit der <a
 				href="https://www.philso.uni-augsburg.de/lehrstuehle/schulpaed/Projekte/Digitalisierung/Lernen-4_0-in-der-Praxis/"
 				target="_blank">Universität Augsburg</a>
-			einen MOOC zu dem Thema <a href="https://www.schulportal-thueringen.de/tio" target="_blank">Lernen 4.0 -
+			einen MOOC zu dem Thema <a href="{{getConfig "TRAINING_URL"}}" target="_blank">Lernen 4.0 -
 				Möglichkeiten und Grenzen einer Digitalisierung im Bildungsbereich</a> durchgeführt.</p>
 		<br />
 		<div class="embed-pdf">

--- a/views/community/community.hbs
+++ b/views/community/community.hbs
@@ -42,7 +42,7 @@
 			<div id="collapseBrb" class="collapse" aria-labelledby="brbAccordion" data-parent="#accordionRegistration">
 				<div class="card-body p-1">
 					{{$t "community.text.inBrandenburgTheAdmissionOfNewSchools"}}<br>
-					{{$t "community.text.forGeneralQuestionsPleaseContact"}}<br> 
+					{{$t "community.text.forGeneralQuestionsPleaseContact"}}<br>
 					<a href="mailto:schul-cloud@bildungsserver.berlin-brandenburg.de">schul-cloud@bildungsserver.berlin-brandenburg.de</a>
 				</div>
 			</div>
@@ -84,8 +84,8 @@
 	</div>
 
 	<p class="mt-3">
-		{{$t "community.text.youCanGetSupport"}} <a href="https://lernen.cloud/"
-			target="_blank">https://lernen.cloud</a>.
+		{{$t "community.text.youCanGetSupport"}} <a href="{{getConfig "TRAINING_URL"}}"
+			target="_blank">{{{getConfig "TRAINING_URL"}}}</a>.
 	</p>
 	{{/content}}
 	{{/embed}}

--- a/views/firstLogin/components/welcome_greeting.hbs
+++ b/views/firstLogin/components/welcome_greeting.hbs
@@ -24,7 +24,7 @@
                         {{$t "firstLogin.thanks.text.youAreAdminAndHaveTheHonorable" (dict "title" @root.theme.title)}} <b>{{$t "firstLogin.thanks.img_alt.onlineTraining"}}</b> {{$t "firstLogin.thanks.text.andLearnEverythingYouNeed"}}
                     </p>
                     <div class="text-xs-center text-sm-right">
-                        <a class="btn btn-warning" target="_blank" rel="noopener noreferrer" href="https://lernen.cloud/">{{$t "firstLogin.text.clickHereForFurtherTraining" }}</a>
+                        <a class="btn btn-warning" target="_blank" rel="noopener noreferrer" href="{{getConfig "TRAINING_URL"}}">{{$t "firstLogin.text.clickHereForFurtherTraining" }}</a>
                     </div>
                 </div>
             </div>
@@ -39,7 +39,7 @@
                             {{$t "firstLogin.thanks.text.whatCanActuallyDo" (dict "shortTitle" @root.theme.short_title)}} <b>{{$t "firstLogin.thanks.img_alt.onlineTraining"}}</b> {{$t "firstLogin.thanks.text.forVividAndPracticalVideos"}}
                         </p>
                         <div class="text-xs-center text-sm-right">
-                            <a class="btn btn-warning" target="_blank" rel="noopener noreferrer" href="https://lernen.cloud/">{{$t "firstLogin.text.clickHereForFurtherTraining" }}</a>
+                            <a class="btn btn-warning" target="_blank" rel="noopener noreferrer" href="{{getConfig "TRAINING_URL"}}">{{$t "firstLogin.text.clickHereForFurtherTraining" }}</a>
                         </div>
                     </div>
                 </div>

--- a/views/help/partials/help_nutzungshilfen.hbs
+++ b/views/help/partials/help_nutzungshilfen.hbs
@@ -1,11 +1,11 @@
 {{#if (userHasRole "student" )}}
 	{{#embed "help/icon-card" title="Nutzungshilfen" icon="fa-map-signs" class="quickHelp-card col-xs-12 help-icon-card" id="nutzungshilfen"}}
 		{{#content "card-body"}}
-			{{> "help/icon-link-group" links=(jsonParse '[
+			{{> "help/icon-link-group" links=(jsonParse (concat '[
 				{
 					"title": "Online-Videokurse",
 					"icon": "fa-video-camera",
-					"src": "https://lernen.cloud/"
+					"src": "' (getConfig "TRAINING_URL") '"
 				},
 				{
 					"title": "Live-Formate",
@@ -22,17 +22,17 @@
 					"icon": "fa-clipboard",
 					"src": "/system/releases"
 				}
-			]') link-class="col-sm-4"}}
+			]')) link-class="col-sm-4"}}
 		{{/content}}
 	{{/embed}}
 {{else}}
 	{{#embed "help/icon-card" title="Nutzungshilfen" icon="fa-map-signs" class="quickHelp-card col-xs-12 help-icon-card" id="nutzungshilfen"}}
 		{{#content "card-body"}}
-			{{> "help/icon-link-group" links=(jsonParse '[
+			{{> "help/icon-link-group" links=(jsonParse (concat '[
 				{
 					"title": "Online-Videokurse",
 					"icon": "fa-video-camera",
-					"src": "https://lernen.cloud/"
+					"src": "' (getConfig "TRAINING_URL") '"
 				},
 				{
 					"title": "Live-Formate",
@@ -54,7 +54,7 @@
 					"icon": "fa-clipboard",
 					"src": "/system/releases"
 				}
-			]') link-class="col-sm-4"}}
+			]')) link-class="col-sm-4"}}
 		{{/content}}
 	{{/embed}}
 {{/if}}

--- a/views/lib/help_menu.hbs
+++ b/views/lib/help_menu.hbs
@@ -89,7 +89,7 @@
                         ></path></svg>
 
                     <a
-                        href="https://lernen.cloud/"
+                        href="{{getConfig "TRAINING_URL"}}"
                         target="_blank"
                         class="link"
                         data-testid="Fortbildung"


### PR DESCRIPTION
# Description
Changing the location of the video training material to a separate federal state location for each state.
For that a new env var `TRAINING_URL` is introduced.

+ editing `ACCESSIBILITY_REPORT_EMAIL` for dBC (currently not visible, just for keeping it up to date)

<!--
  This is a template to add as much information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and end-to-end-tests), also for error cases
    - Business logic should be implemented in the API; never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
<!--
Base links to copy
- https://github.com/schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->
BC-7700
BC-7701
BC-7702

https://github.com/hpi-schul-cloud/dof_app_deploy/pull/929
https://github.com/hpi-schul-cloud/schulcloud-server/pull/5170
https://github.com/hpi-schul-cloud/nuxt-client/pull/3350

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
