### PR TITLE
BC-8292 - add hint and link for user survey 2024

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -1250,6 +1250,7 @@
 		},
 		"text": {
 			"announcementBrb": "Neu bei bettermarks: <a target='_blank' rel='noopener noreferrer' href='https://de.bettermarks.com/unterrichten'>Fertige Unterrichtseinheiten jetzt für Klasse 5 bis 8</a> und neue <a target='_blank' rel='noopener noreferrer' href='https://de.bettermarks.com/ueben-testen'>Übungs- und Testaufgaben für Jahrgangsstufe 4 bis 13</a>!<br> <a target='_blank' rel='noopener noreferrer' href='https://bbb3.bsbb.eu/hedgedoc/s/qIIjH-LWN#'>Hier</a> finden Sie unsere Kursbeispiele/Themenvorschläge für die Schul-Cloud Brandenburg: einsehen, auswählen und als eigenen Kurs <a target='_blank' rel='noopener noreferrer' href='https://docs.dbildungscloud.de/pages/viewpage.action?pageId=39387173#Kurseteilenundimportieren-Kursimportieren'>importieren</a>!",
+			"announcement": "Nehmen Sie an unserer Zufriedenheitsumfrage teil und helfen Sie uns, die Cloud zu verbessern. <a href=\"https://befragungen.dataport.de/umfrage/1891615/SyBxM9\" target=\"_blank\">Hier</a> geht’s zur Befragung.",
 			"emptyHomeworksInfo": "Keine gestellten Aufgaben. Du findest alle Aufgaben im Aufgaben-Bereich.",
 			"emptyNewsInfo": "Bisher gibt es keine News.",
 			"graded": "Bewertet",

--- a/locales/en.json
+++ b/locales/en.json
@@ -1250,7 +1250,7 @@
 		},
 		"text": {
 			"announcementBrb": "New at bettermarks: <a target='_blank' rel='noopener noreferrer' href='https://de.bettermarks.com/unterrichten'>Ready-made teaching units now for grades 5 to 8</a> and new <a target='_blank' rel='noopener noreferrer' href='https://de.bettermarks.com/ueben-testen'>exercises and tests for grades 4 to 13</a>!<br> <a target='_blank' rel='noopener noreferrer' href='https://bbb3.bsbb.eu/hedgedoc/s/qIIjH-LWN#'>Here</a> you can find our course examples/topic suggestions for the Brandenburg School Cloud: view, select and <a target='_blank' rel='noopener noreferrer' href='https://docs.dbildungscloud.de/pages/viewpage.action?pageId=39387173#Kurseteilenundimportieren-Kursimportieren'>import</a> as your own course!",
-			"announcement": "Take part in our satisfaction survey and help us to improve the cloud. Click <a href=\"https://befragungen.dataport.de/umfrage/1891615/SyBxM9\" target=\"_blank\">here</a> to go to the survey.",
+			"announcement": "Take part in our satisfaction survey and help us to improve the cloud. Click <a href=\"https://befragungen.dataport.de/umfrage/1891615/SyBxM9\" target=\"_blank\">here</a> to go to the survey (exclusively in German language).",
 			"emptyHomeworksInfo": "No assigned tasks. You can find all tasks in the tasks area.",
 			"emptyNewsInfo": "So far there is no news.",
 			"graded": "Graded",

--- a/locales/en.json
+++ b/locales/en.json
@@ -1250,6 +1250,7 @@
 		},
 		"text": {
 			"announcementBrb": "New at bettermarks: <a target='_blank' rel='noopener noreferrer' href='https://de.bettermarks.com/unterrichten'>Ready-made teaching units now for grades 5 to 8</a> and new <a target='_blank' rel='noopener noreferrer' href='https://de.bettermarks.com/ueben-testen'>exercises and tests for grades 4 to 13</a>!<br> <a target='_blank' rel='noopener noreferrer' href='https://bbb3.bsbb.eu/hedgedoc/s/qIIjH-LWN#'>Here</a> you can find our course examples/topic suggestions for the Brandenburg School Cloud: view, select and <a target='_blank' rel='noopener noreferrer' href='https://docs.dbildungscloud.de/pages/viewpage.action?pageId=39387173#Kurseteilenundimportieren-Kursimportieren'>import</a> as your own course!",
+			"announcement": "Take part in our satisfaction survey and help us to improve the cloud. Click <a href=\"https://befragungen.dataport.de/umfrage/1891615/SyBxM9\" target=\"_blank\">here</a> to go to the survey.",
 			"emptyHomeworksInfo": "No assigned tasks. You can find all tasks in the tasks area.",
 			"emptyNewsInfo": "So far there is no news.",
 			"graded": "Graded",

--- a/locales/es.json
+++ b/locales/es.json
@@ -1250,7 +1250,7 @@
 		},
 		"text": {
 			"announcementBrb": "Nuevo en bettermarks: <a target='_blank' rel='noopener noreferrer' href='https://de.bettermarks.com/unterrichten'>Unidades didácticas preparadas ahora para los cursos 5º a 8º</a> y nuevos <a target='_blank' rel='noopener noreferrer' href='https://de.bettermarks.com/ueben-testen'>ejercicios y tests para los cursos 4º a 13º</a>!<br> <a target='_blank' rel='noopener noreferrer' href='https://bbb3.bsbb.eu/hedgedoc/s/qIIjH-LWN#'>Aquí</a> puede encontrar nuestros ejemplos de cursos/sugerencias de temas para la Nube Escolar de Brandenburgo: ¡visualícelos, selecciónelos e <a target='_blank' rel='noopener noreferrer' href='https://docs.dbildungscloud.de/pages/viewpage.action?pageId=39387173#Kurseteilenundimportieren-Kursimportieren'>impórtelos</a> como su propio curso!",
-			"announcement": "Participe en nuestra encuesta de satisfacción y ayúdenos a mejorar la nube. Haga clic <a href=\"https://befragungen.dataport.de/umfrage/1891615/SyBxM9\" target=\"_blank\">aquí</a> para acceder a la encuesta.",
+			"announcement": "Participe en nuestra encuesta de satisfacción y ayúdenos a mejorar la nube. Haga clic <a href=\"https://befragungen.dataport.de/umfrage/1891615/SyBxM9\" target=\"_blank\">aquí</a> para acceder a la encuesta (exclusivamente en alemán).",
 			"emptyHomeworksInfo": "No hay tareas asignadas. Puedes encontrarar todas las tareas en el área de tareas.",
 			"emptyNewsInfo": "Hasta el momento no hay noticias.",
 			"graded": "Calificado",

--- a/locales/es.json
+++ b/locales/es.json
@@ -1250,6 +1250,7 @@
 		},
 		"text": {
 			"announcementBrb": "Nuevo en bettermarks: <a target='_blank' rel='noopener noreferrer' href='https://de.bettermarks.com/unterrichten'>Unidades didácticas preparadas ahora para los cursos 5º a 8º</a> y nuevos <a target='_blank' rel='noopener noreferrer' href='https://de.bettermarks.com/ueben-testen'>ejercicios y tests para los cursos 4º a 13º</a>!<br> <a target='_blank' rel='noopener noreferrer' href='https://bbb3.bsbb.eu/hedgedoc/s/qIIjH-LWN#'>Aquí</a> puede encontrar nuestros ejemplos de cursos/sugerencias de temas para la Nube Escolar de Brandenburgo: ¡visualícelos, selecciónelos e <a target='_blank' rel='noopener noreferrer' href='https://docs.dbildungscloud.de/pages/viewpage.action?pageId=39387173#Kurseteilenundimportieren-Kursimportieren'>impórtelos</a> como su propio curso!",
+			"announcement": "Participe en nuestra encuesta de satisfacción y ayúdenos a mejorar la nube. Haga clic <a href=\"https://befragungen.dataport.de/umfrage/1891615/SyBxM9\" target=\"_blank\">aquí</a> para acceder a la encuesta.",
 			"emptyHomeworksInfo": "No hay tareas asignadas. Puedes encontrarar todas las tareas en el área de tareas.",
 			"emptyNewsInfo": "Hasta el momento no hay noticias.",
 			"graded": "Calificado",

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -10,7 +10,7 @@
 		},
 		"text": {
 			"announcementBrb": "Нове на bettermarks: <a target='_blank' rel='noopener noreferrer' href='https://de.bettermarks.com/unterrichten'>Готові навчальні блоки для 5-8 класів</a> та нові <a target='_blank' rel='noopener noreferrer' href='https://de.bettermarks.com/ueben-testen'>вправи і тести для 4-13 класів</a>!<br> <a target='_blank' rel='noopener noreferrer' href='https://bbb3.bsbb.eu/hedgedoc/s/qIIjH-LWN#'>Тут</a> ви можете знайти приклади наших курсів/пропозиції тем для Бранденбурзької шкільної хмари: переглядайте, обирайте та <a target='_blank' rel='noopener noreferrer' href='https://docs.dbildungscloud.de/pages/viewpage.action?pageId=39387173#Kurseteilenundimportieren-Kursimportieren'>імпортуйте</a> як свій власний курс!",
-			"announcement": "Візьміть участь у нашому опитуванні та допоможіть нам покращити хмару. Натисніть <a href=\"https://befragungen.dataport.de/umfrage/1891615/SyBxM9\" target=\"_blank\">тут</a>, щоб пройти опитування.",
+			"announcement": "Візьміть участь у нашому опитуванні та допоможіть нам покращити хмару. Натисніть <a href=\"https://befragungen.dataport.de/umfrage/1891615/SyBxM9\" target=\"_blank\">тут</a>, щоб пройти опитування (виключно німецькою мовою).",
 			"notFound": "Активних записів не знайдено.",
 			"emptyHomeworksInfo": "Усі домашні завдання показуються в розділі домашніх завдань.",
 			"emptyNewsInfo": "Немає останніх новин. Перегляньте розділ новин, щоб бути в курсі.",

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -10,6 +10,7 @@
 		},
 		"text": {
 			"announcementBrb": "Нове на bettermarks: <a target='_blank' rel='noopener noreferrer' href='https://de.bettermarks.com/unterrichten'>Готові навчальні блоки для 5-8 класів</a> та нові <a target='_blank' rel='noopener noreferrer' href='https://de.bettermarks.com/ueben-testen'>вправи і тести для 4-13 класів</a>!<br> <a target='_blank' rel='noopener noreferrer' href='https://bbb3.bsbb.eu/hedgedoc/s/qIIjH-LWN#'>Тут</a> ви можете знайти приклади наших курсів/пропозиції тем для Бранденбурзької шкільної хмари: переглядайте, обирайте та <a target='_blank' rel='noopener noreferrer' href='https://docs.dbildungscloud.de/pages/viewpage.action?pageId=39387173#Kurseteilenundimportieren-Kursimportieren'>імпортуйте</a> як свій власний курс!",
+			"announcement": "Візьміть участь у нашому опитуванні та допоможіть нам покращити хмару. Натисніть <a href=\"https://befragungen.dataport.de/umfrage/1891615/SyBxM9\" target=\"_blank\">тут</a>, щоб пройти опитування.",
 			"notFound": "Активних записів не знайдено.",
 			"emptyHomeworksInfo": "Усі домашні завдання показуються в розділі домашніх завдань.",
 			"emptyNewsInfo": "Немає останніх новин. Перегляньте розділ новин, щоб бути в курсі.",


### PR DESCRIPTION
# Description
Present a hint containing a link to the user survey 2024 on the start page (dashboard).

## Links to Tickets or other pull requests
BC-8292
https://github.com/hpi-schul-cloud/dof_app_deploy/pull/1004

## Changes
- added translations

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
