### PR TITLE
BC-8356 - Bettermarks and other oauth apps not openable if user double clicks on consent button

### DIFF
--- a/static/scripts/consent.js
+++ b/static/scripts/consent.js
@@ -1,0 +1,8 @@
+window.addEventListener('DOMContentLoaded', () => {
+	const form = document.querySelector('.registration-form');
+	const submitButton = form.querySelector('input[type="submit"]');
+
+	form.addEventListener('submit', () => {
+		submitButton.disabled = true;
+	});
+});

--- a/views/oauth2/consent.hbs
+++ b/views/oauth2/consent.hbs
@@ -3,6 +3,9 @@
         <link rel="stylesheet" href="{{getAssetPath '/styles/authentication/home.css'}}"/>
         <link rel="stylesheet" href="{{getAssetPath '/styles/authentication/login.css'}}"/>
     {{/content}}
+    {{#content "scripts" mode="append"}}
+        <script src="{{getAssetPath '/scripts/consent.js'}}" type="text/javascript" nonce="{{nonceValue}}" defer></script>
+    {{/content}}
     {{#content "body"}}
         <main class="container">
             <div class="row">


### PR DESCRIPTION
# Description
<!--
  This is a template to add as much information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and end-to-end-tests), also for error cases
    - Business logic should be implemented in the API; never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->
User can have multiple pending requests at a time in the form that submits the consent for oauth operations (that affects at least bettermarks)

## Links to Tickets or other pull requests
<!--
Base links to copy
- https://github.com/schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->
BC-8356
## Changes
- "Akzeptieren" button (see screenshot) will be disabled after first click, no option to send two requests anymore
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Screenshots of UI changes
<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->
<img width="535" alt="grafik" src="https://github.com/user-attachments/assets/48d68270-e6ef-4489-81a3-fa1eaa9a9c07" />

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
