### PR TITLE
BC-8989 - Replacement of the LISUM-logo on the login/start page with libra-logo

### DIFF
--- a/static/styles/authentication/home.scss
+++ b/static/styles/authentication/home.scss
@@ -184,6 +184,6 @@ body {
 
 .partner-img {
 	img {
-		padding: 5px 20px;
+		padding: 10px 20px;
 	}
 }

--- a/theme/brb/views/authentication/home.hbs
+++ b/theme/brb/views/authentication/home.hbs
@@ -90,7 +90,7 @@
 								class="img-fluid">
 						</a>
 						<a href="https://libra.brandenburg.de" target="_blank" rel="noopener">
-							<img src="https://s3.hidrive.strato.com/cloud-instances/brb/images/libra.PNG"
+							<img src="https://s3.hidrive.strato.com/cloud-instances/brb/images/libra.png"
 								alt="Logo Libra" class="img-fluid">
 						</a>
 						<a aria-label="Dataport Logo" target="_blank" rel="noopener" href="https://www.dataport.de/" alt="Logo Dataport">

--- a/theme/brb/views/authentication/home.hbs
+++ b/theme/brb/views/authentication/home.hbs
@@ -94,7 +94,7 @@
 								alt="Logo Libra" class="img-fluid">
 						</a>
 						<a aria-label="Dataport Logo" target="_blank" rel="noopener" href="https://www.dataport.de/" alt="Logo Dataport">
-                            <svg class="img-fluid SectionHeader-logo u-scalingInlineSVG" focusable="false" role="img" aria-hidden="true" viewBox="0 0 173 60" version="1.1" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMin slice" style="padding-top: 5%;">
+                            <svg class="img-fluid SectionHeader-logo u-scalingInlineSVG" focusable="false" role="img" aria-hidden="true" viewBox="0 0 173 60" version="1.1" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMin slice" style="padding: 20px 20px 0 20px;">
                                 <g stroke="none" fill="none" fill-rule="evenodd">
                                     <g class="HeaderLogo-small" transform="translate(120.066900, 0.000000)">
                                         <rect x="0" y="0" width="22" height="60"></rect>

--- a/theme/brb/views/authentication/home.hbs
+++ b/theme/brb/views/authentication/home.hbs
@@ -89,9 +89,9 @@
 							<img src="https://cloud-instances.s3.hidrive.strato.com/brb/images/mbjs.png" alt="Logo MBJS"
 								class="img-fluid">
 						</a>
-						<a href="https://lisum.berlin-brandenburg.de/lisum/" target="_blank" rel="noopener">
-							<img src="https://cloud-instances.s3.hidrive.strato.com/brb/images/lisum.png"
-								alt="Logo LISUM" class="img-fluid">
+						<a href="https://libra.brandenburg.de" target="_blank" rel="noopener">
+							<img src="https://s3.hidrive.strato.com/cloud-instances/brb/images/libra.PNG"
+								alt="Logo Libra" class="img-fluid">
 						</a>
 						<a aria-label="Dataport Logo" target="_blank" rel="noopener" href="https://www.dataport.de/" alt="Logo Dataport">
                             <svg class="img-fluid SectionHeader-logo u-scalingInlineSVG" focusable="false" role="img" aria-hidden="true" viewBox="0 0 173 60" version="1.1" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMin slice" style="padding-top: 5%;">

--- a/theme/brb/views/authentication/home.hbs
+++ b/theme/brb/views/authentication/home.hbs
@@ -94,7 +94,7 @@
 								alt="Logo Libra" class="img-fluid">
 						</a>
 						<a aria-label="Dataport Logo" target="_blank" rel="noopener" href="https://www.dataport.de/" alt="Logo Dataport">
-                            <svg class="img-fluid SectionHeader-logo u-scalingInlineSVG" focusable="false" role="img" aria-hidden="true" viewBox="0 0 173 60" version="1.1" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMin slice" style="padding: 20px 20px 0 20px;">
+                            <svg class="img-fluid SectionHeader-logo u-scalingInlineSVG" focusable="false" role="img" aria-hidden="true" viewBox="0 0 173 60" version="1.1" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMin slice" style="padding: 20px 20px 0 20px; max-width: 315px;">
                                 <g stroke="none" fill="none" fill-rule="evenodd">
                                     <g class="HeaderLogo-small" transform="translate(120.066900, 0.000000)">
                                         <rect x="0" y="0" width="22" height="60"></rect>

--- a/theme/brb/views/authentication/home.hbs
+++ b/theme/brb/views/authentication/home.hbs
@@ -90,7 +90,7 @@
 								class="img-fluid">
 						</a>
 						<a href="https://libra.brandenburg.de" target="_blank" rel="noopener">
-							<img src="https://s3.hidrive.strato.com/cloud-instances/brb/images/libra.png"
+							<img src="https://cloud-instances.s3.hidrive.strato.com/brb/images/libra.png"
 								alt="Logo Libra" class="img-fluid">
 						</a>
 						<a aria-label="Dataport Logo" target="_blank" rel="noopener" href="https://www.dataport.de/" alt="Logo Dataport">


### PR DESCRIPTION
https://ticketsystem.dbildungscloud.de/browse/BC-8989

Short description
In the SC BB, the former logo of the Lisum is to be replaced by the new Libra logo. 

The link should be changed to https://libra.brandenburg.de/

Steps to reproduce
Go to https://brandenburg.cloud/ --> scroll down to "Projektdurchführung" -> Logos
Current result
LISUM Logo with link to LISUM
Expected result
libra Logo with link to libra

## Screenshots of UI changes

<!--
- For UI changes, insert screenshots here.
- Has it been reviewed by a UX colleague?
-->

![grafik](https://github.com/user-attachments/assets/2964065b-caca-4bc0-a62c-f6ac5efc792c)


## Checklist before merging

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)