### PR TITLE
BC-8966 - Delete text in teams share settings

### DIFF
--- a/views/teams/forms/form-file-permissions.hbs
+++ b/views/teams/forms/form-file-permissions.hbs
@@ -7,8 +7,6 @@
     <strong>{{$t "teams._team.text.theseSettingsWillBeAppliedToNewFiles"}}</strong>
     <br><br>
     <table class="team-file-permissions">
-    <caption class="h4"><h2 class="h4">{{$t "teams._team.headline.shareFilesSettings"}}</h2>
-    <strong>{{$t "teams._team.text.theseSettingsWillBeAppliedToNewFiles"}}</strong></caption>
         <tr>
             <th scope="col">{{$t "global.label.role"}}</th>
             <th scope="col">{{$t "teams._team.label.accessToData"}}</th>


### PR DESCRIPTION
# Description
Inside the dialog "change share settings" the text "File sharing settings The following permissions will be activated for newly uploaded/created folders and files within the team:" is there 2x. The second one should be deleted.
<!--
  This is a template to add as much information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and end-to-end-tests), also for error cases
    - Business logic should be implemented in the API; never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
BC-8966
<!--
Base links to copy
- https://github.com/schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->

## Screenshots of UI changes
<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->
<img width="617" alt="grafik" src="https://github.com/user-attachments/assets/a3800fc3-bb71-4078-aa19-eaeaef0ee367" />


## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
