### PR TITLE
BC-9619 - Inactive and unsorted buttons in team-files

### DIFF
--- a/static/styles/files/files.scss
+++ b/static/styles/files/files.scss
@@ -368,4 +368,8 @@
       margin: auto;
     }
   }
+
+  .clearfix::after {
+		clear: both;
+	}
 }

--- a/views/files/file-upload.hbs
+++ b/views/files/file-upload.hbs
@@ -14,6 +14,6 @@
                     <div class="bar" style="width:0%">&nbsp;</div>
                 </div>
             </div>
-        </button>
+        </div>
     </div>
 </section>

--- a/views/files/files.hbs
+++ b/views/files/files.hbs
@@ -12,7 +12,7 @@
 
 {{#content "page"}}
 <div class="route-files">
-		<div style="clear: both">
+		<div class="clearfix">
             {{#if useNextcloud}}
                 <a href="{{../nextcloudUrl}}" target="_blank" class="btn btn-add btn-primary pull-right{{#unless ../nextcloudUrl}}disabled{{/unless}}" style="margin-left: 5px">
                     <i class="fa fa-external-link" aria-hidden="true"></i>


### PR DESCRIPTION
# Description

Buttons in course and team files are broken due to wrong clearance styling.
<!--
  This is a template to add as much information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and end-to-end-tests), also for error cases
    - Business logic should be implemented in the API; never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
BC-9619
<!--
Base links to copy
- https://github.com/schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.dbildungscloud.de/browse/BC-????
-->

## Changes
- clear floating of files buttons after rendering due to conditional rendering
<!--
  What will the PR change?
  Why are the changes required?
  Short notice if a ticket exists, more detailed if not
-->

## Screenshots of UI changes
<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

<img width="1352" alt="grafik" src="https://github.com/user-attachments/assets/1238256a-6b9a-444f-9194-2a5827d4b55a" />


## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
