### PR TITLE
BC-12137 - fix html injection for oauth2-error endpoint

### DIFF
--- a/controllers/oauth2.js
+++ b/controllers/oauth2.js
@@ -3,6 +3,7 @@ const express = require('express');
 const router = express.Router();
 const csrf = require('csurf');
 const { Configuration } = require('@hpi-schul-cloud/commons');
+const { stripHtml } = require('string-strip-html');
 const auth = require('../helpers/authentication');
 const api = require('../api');
 
@@ -84,7 +85,9 @@ router.get('/consent', csrfProtection, auth.authChecker, (req, res, next) => {
 	// This endpoint is hit when hydra initiates the consent flow
 	if (req.query.error) {
 		// An error occurred (at hydra)
-		return res.send(`${req.query.error}<br />${req.query.error_description}`);
+		const sanitizedError = stripHtml(req.query.error);
+		const sanitizedErrorDiscription = stripHtml(req.query.error_description);
+		return res.send(`${sanitizedError}<br />${sanitizedErrorDiscription}`);
 	}
 	return api(req, { version: 'v3' })
 		.get(`/oauth2/consentRequest/${req.query.consent_challenge}`)

--- a/controllers/oauth2.js
+++ b/controllers/oauth2.js
@@ -85,8 +85,10 @@ router.get('/consent', csrfProtection, auth.authChecker, (req, res, next) => {
 	// This endpoint is hit when hydra initiates the consent flow
 	if (req.query.error) {
 		// An error occurred (at hydra)
-		const sanitizedError = stripHtml(req.query.error);
-		const sanitizedErrorDiscription = stripHtml(req.query.error_description);
+		const error = req.query.error ? req.query.error : 'undefined';
+		const errorDescription = req.query.error_description ? req.query.error_description : 'undefined';
+		const sanitizedError = encodeURIComponent(stripHtml(error).result);
+		const sanitizedErrorDiscription = encodeURIComponent(stripHtml(errorDescription).result);
 		return res.send(`${sanitizedError}<br />${sanitizedErrorDiscription}`);
 	}
 	return api(req, { version: 'v3' })

--- a/controllers/oauth2.js
+++ b/controllers/oauth2.js
@@ -88,8 +88,8 @@ router.get('/consent', csrfProtection, auth.authChecker, (req, res, next) => {
 		const error = req.query.error ? req.query.error : 'undefined';
 		const errorDescription = req.query.error_description ? req.query.error_description : 'undefined';
 		const sanitizedError = encodeURIComponent(stripHtml(error).result);
-		const sanitizedErrorDiscription = encodeURIComponent(stripHtml(errorDescription).result);
-		return res.send(`${sanitizedError}<br />${sanitizedErrorDiscription}`);
+		const sanitizedErrorDescription = encodeURIComponent(stripHtml(errorDescription).result);
+		return res.send(`${sanitizedError}<br />${sanitizedErrorDescription}`);
 	}
 	return api(req, { version: 'v3' })
 		.get(`/oauth2/consentRequest/${req.query.consent_challenge}`)


### PR DESCRIPTION
# Description
Fix possible html injection point for oauth2-error-endpoint.

## Links to Tickets or other pull requests
BC-12137

## Changes
- sanitization of transfered user-data

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
