### PR TITLE
BC-12143 - remove working limitation to six files on team-page

### DIFF
--- a/controllers/teams.js
+++ b/controllers/teams.js
@@ -446,8 +446,7 @@ async function fetchRootTeamFilesAndDirectories(req, course, roles) {
 	files = files.filter((file) => file);
 
 	const directories = files.filter((f) => f.isDirectory)
-		.toSorted(sortByUpdatedAtDescending)
-		.slice(0, 6);
+		.toSorted(sortByUpdatedAtDescending);
 
 	files = files.map((file) => {
 		// set saveName attribute with escaped quotes and encoded specific characters
@@ -462,9 +461,7 @@ async function fetchRootTeamFilesAndDirectories(req, course, roles) {
 
 	files = files.filter((f) => !f.isDirectory);
 
-	// Sort by most recent files and limit to 6 files
 	files = files.toSorted(sortByUpdatedAtDescending)
-		.slice(0, 6)
 		.map(addThumbnails);
 
 	return { directories, files };


### PR DESCRIPTION
# Description
Refactoring of code activated a limitation to six files on the teams-detail-page, that was intended but never worked.

## Links to Tickets or other pull requests
- https://ticketsystem.dbildungscloud.de/browse/BC-12143
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/6434
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/3880

## Changes
- removed slicing the list to max. 6 files

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
