### PR TITLE
BC-12163 - fix etherpad filtering

### DIFF
--- a/controllers/topics.js
+++ b/controllers/topics.js
@@ -240,8 +240,11 @@ router.get('/:topicId', async (req, res, next) => {
 					});
 
 					const sessionInfo = await getEtherpadSession(req, res, req.params.courseId);
+					console.log('req.params', req.params); // TODO: remove debug
+					console.log('sessionInfo', sessionInfo); // TODO: remove debug
 					const { validUntil } = sessionInfo || {};
 					const sessionIds = await getActiveSessions(req);
+					console.log('sessionIds', sessionIds); // TODO: remove debug
 					authHelper.etherpadCookieHelper(sessionIds, validUntil, res);
 					return lesson;
 				}

--- a/controllers/topics.js
+++ b/controllers/topics.js
@@ -128,17 +128,18 @@ async function createNewEtherpad(req, res, contents = [], courseId) {
 
 const getEtherpadSession = (req, res, courseId) => api(req).post(
 	'/etherpad/sessions', { json: { courseId } },
-).catch((err) => {
-	logger.error(err.message);
-	return undefined;
-});
+)
+	.then((response) => response.data)
+	.catch((err) => {
+		logger.error(err.message);
+		return undefined;
+	});
 
-const getActiveSessions = (req, res) => api(req).get(
-	'/etherpad/active-sessions', {},
-).catch((err) => {
-	logger.error(err.message);
-	return undefined;
-});
+const getActiveSessions = (req) => api(req).get('/etherpad/active-sessions')
+	.catch((err) => {
+		logger.error(err.message);
+		return undefined;
+	});
 
 const validatePadDomain = (url) => {
 	const whitelist = [
@@ -240,11 +241,8 @@ router.get('/:topicId', async (req, res, next) => {
 
 					const sessionInfo = await getEtherpadSession(req, res, req.params.courseId);
 					const { validUntil } = sessionInfo || {};
-
-					const sessionIds = await getActiveSessions(req, res);
-					etherpadPads.forEach((padId) => {
-						authHelper.etherpadCookieHelper(sessionIds, validUntil, padId, res);
-					});
+					const sessionIds = await getActiveSessions(req);
+					authHelper.etherpadCookieHelper(sessionIds, validUntil, res);
 					return lesson;
 				}
 

--- a/controllers/topics.js
+++ b/controllers/topics.js
@@ -135,12 +135,6 @@ const getEtherpadSession = (req, res, courseId) => api(req).post(
 		return undefined;
 	});
 
-const getActiveSessions = (req) => api(req).get('/etherpad/active-sessions')
-	.catch((err) => {
-		logger.error(err.message);
-		return undefined;
-	});
-
 const validatePadDomain = (url) => {
 	const whitelist = [
 		Configuration.get('ETHERPAD__DOMAIN'),
@@ -240,12 +234,8 @@ router.get('/:topicId', async (req, res, next) => {
 					});
 
 					const sessionInfo = await getEtherpadSession(req, res, req.params.courseId);
-					console.log('req.params', req.params); // TODO: remove debug
-					console.log('sessionInfo', sessionInfo); // TODO: remove debug
-					const { validUntil } = sessionInfo || {};
-					const sessionIds = await getActiveSessions(req);
-					console.log('sessionIds', sessionIds); // TODO: remove debug
-					authHelper.etherpadCookieHelper(sessionIds, validUntil, res);
+					const { activeSessionIds, validUntil } = sessionInfo || {};
+					authHelper.etherpadCookieHelper(activeSessionIds, validUntil, res);
 					return lesson;
 				}
 

--- a/controllers/topics.js
+++ b/controllers/topics.js
@@ -218,29 +218,31 @@ router.get('/:topicId', (req, res, next) => {
 	Promise.all([
 		api(req).get(`/${context}/${req.params.courseId}`),
 		api(req, { version: 'v3' }).get(`/lessons/${req.params.topicId}`).then((lesson) => {
-			const etherpadPads = [];
-			if (typeof lesson.contents !== 'undefined') {
-				lesson.contents = lesson.contents.filter((element) => {
-					if (element.component === 'Etherpad') {
-						if (featureEtherpadEnabled) {
+			if (lesson.contents !== undefined) {
+				if (featureEtherpadEnabled) {
+					const etherpadPads = [];
+					lesson.contents.forEach((element) => {
+						if (element.component === 'Etherpad') {
 							const { url } = element.content;
 							const padId = getPadIdFromUrl(url);
-							// set cookie for this pad
-							if (typeof (padId) !== 'undefined') {
+							if (padId !== undefined) {
 								etherpadPads.push(padId);
 							}
 						}
-						return false;
-					}
-					return true;
-				});
-			}
-			if (featureEtherpadEnabled && typeof lesson.contents !== 'undefined') {
-				return getEtherpadSession(req, res, req.params.courseId).then((sessionInfo) => {
-					etherpadPads.forEach((padId) => {
-						authHelper.etherpadCookieHelper(sessionInfo, padId, res);
 					});
-				}).then(() => lesson);
+
+					return getEtherpadSession(req, res, req.params.courseId)
+						.then((sessionInfo) => {
+							etherpadPads.forEach((padId) => {
+								authHelper.etherpadCookieHelper(sessionInfo, padId, res);
+							});
+						})
+						.then(() => lesson);
+				}
+
+				if (featureEtherpadEnabled === false) {
+					lesson.contents = lesson.contents.filter((element) => element.component !== 'Etherpad');
+				}
 			}
 			return lesson;
 		}),

--- a/controllers/topics.js
+++ b/controllers/topics.js
@@ -133,6 +133,13 @@ const getEtherpadSession = (req, res, courseId) => api(req).post(
 	return undefined;
 });
 
+const getActiveSessions = (req, res) => api(req).get(
+	'/etherpad/active-sessions', {},
+).catch((err) => {
+	logger.error(err.message);
+	return undefined;
+});
+
 const validatePadDomain = (url) => {
 	const whitelist = [
 		Configuration.get('ETHERPAD__DOMAIN'),
@@ -213,11 +220,11 @@ router.post('/:id/share', (req, res, next) => {
 });
 
 // eslint-disable-next-line consistent-return
-router.get('/:topicId', (req, res, next) => {
+router.get('/:topicId', async (req, res, next) => {
 	const context = req.originalUrl.split('/')[1];
 	Promise.all([
 		api(req).get(`/${context}/${req.params.courseId}`),
-		api(req, { version: 'v3' }).get(`/lessons/${req.params.topicId}`).then((lesson) => {
+		api(req, { version: 'v3' }).get(`/lessons/${req.params.topicId}`).then(async (lesson) => {
 			if (lesson.contents !== undefined) {
 				if (featureEtherpadEnabled) {
 					const etherpadPads = [];
@@ -231,13 +238,14 @@ router.get('/:topicId', (req, res, next) => {
 						}
 					});
 
-					return getEtherpadSession(req, res, req.params.courseId)
-						.then((sessionInfo) => {
-							etherpadPads.forEach((padId) => {
-								authHelper.etherpadCookieHelper(sessionInfo, padId, res);
-							});
-						})
-						.then(() => lesson);
+					const sessionInfo = await getEtherpadSession(req, res, req.params.courseId);
+					const { validUntil } = sessionInfo || {};
+
+					const sessionIds = await getActiveSessions(req, res);
+					etherpadPads.forEach((padId) => {
+						authHelper.etherpadCookieHelper(sessionIds, validUntil, padId, res);
+					});
+					return lesson;
 				}
 
 				if (featureEtherpadEnabled === false) {

--- a/helpers/authentication.js
+++ b/helpers/authentication.js
@@ -81,7 +81,7 @@ const isAuthenticationInvalidError = (error) => {
 };
 
 const etherpadCookieHelper = (sessionIds, validUntil, res) => {
-	const sessionIdList = sessionIds.filter(Boolean).join(',');
+	const sessionIdList = (sessionIds || []).filter(Boolean).join(',');
 
 	setCookie(res, 'sessionID', sessionIdList, {
 		path: '/etherpad/',

--- a/helpers/authentication.js
+++ b/helpers/authentication.js
@@ -80,12 +80,15 @@ const isAuthenticationInvalidError = (error) => {
 		|| error.error?.className === 'auto-logout';
 };
 
-const etherpadCookieHelper = (etherpadSession, padId, res) => {
-	const encodedPadId = encodeURI(padId);
-	const padPath = Configuration.get('ETHERPAD__PAD_PATH');
-	setCookie(res, 'sessionID', etherpadSession.data.sessionID, {
-		path: `${padPath}/${encodedPadId}`,
-		expires: new Date(etherpadSession.data.validUntil * 1000),
+const etherpadCookieHelper = (sessionIds, validUntil, res) => {
+	const sessionIdList = sessionIds.filter(Boolean).join(',');
+
+	setCookie(res, 'sessionID', sessionIdList, {
+		path: '/etherpad/',
+		secure: true,
+		sameSite: 'lax',
+		httpOnly: true,
+		expires: new Date(validUntil * 1000),
 	});
 };
 

--- a/views/topic/components/content-Etherpad.hbs
+++ b/views/topic/components/content-Etherpad.hbs
@@ -1,11 +1,7 @@
 <h2 class="h4">{{title}}</h2>
 <p>{{content.description}}</p>
-{{#if featureEtherpadEnabled}}
-	{{#if content.url}}
-		<iframe src="{{content.url}}"
-			style="width: 100%; height: 400px; resize: vertical; overflow: auto;"></iframe>
-		<a href="{{content.url}}" target="_blank" class="pull-right">{{$t "global.link.openInNewTab" }}</a>
-	{{/if}}
-{{else}}
-	<div style="vertical-align: center; background: grey; text-align: center;">{{$t "topic._topic.text.etherpadContentDeactivated" }}</div>
+{{#if content.url}}
+	<iframe src="{{content.url}}"
+		style="width: 100%; height: 400px; resize: vertical; overflow: auto;"></iframe>
+	<a href="{{content.url}}" target="_blank" class="pull-right">{{$t "global.link.openInNewTab" }}</a>
 {{/if}}

--- a/views/topic/components/content-Etherpad.hbs
+++ b/views/topic/components/content-Etherpad.hbs
@@ -1,7 +1,7 @@
 <h2 class="h4">{{title}}</h2>
 <p>{{content.description}}</p>
 {{#if featureEtherpadEnabled}}
-	{{#if  content.url}}
+	{{#if content.url}}
 		<iframe src="{{content.url}}"
 			style="width: 100%; height: 400px; resize: vertical; overflow: auto;"></iframe>
 		<a href="{{content.url}}" target="_blank" class="pull-right">{{$t "global.link.openInNewTab" }}</a>


### PR DESCRIPTION
# Description
When the etherpad-feature-flag is set to true, no etherpad-content should be filter from the content-list of a lesson.

## Links to Tickets or other pull requests
[BC-12163](https://ticketsystem.dbildungscloud.de/browse/BC-12163)

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
