### PR TITLE
SVSDEV-112 - switch download-request from get to post

### DIFF
--- a/static/scripts/download.js
+++ b/static/scripts/download.js
@@ -1,37 +1,32 @@
+const appendHiddenInput = (form, name, value) => {
+	const input = document.createElement('input');
+	input.type = 'hidden';
+	input.name = name;
+	input.value = value;
+	form.appendChild(input);
+};
+
 const archiveDownload = (requestBody, selectedFileIds = []) => {
 	const form = document.createElement('form');
-	form.method = 'GET';
+	form.method = 'POST';
 	form.action = '/api/v1/filestorage/files/archive';
 	form.target = '_blank';
+	form.rel = 'noopener';
 
-	const ownerIdInput = document.createElement('input');
-	ownerIdInput.type = 'hidden';
-	ownerIdInput.name = 'ownerId';
-	ownerIdInput.value = requestBody.ownerId;
+	const csrfTokenMetaTag = document.querySelector('meta[name="csrfToken"]');
+	if (csrfTokenMetaTag) {
+		appendHiddenInput(form, '_csrf', csrfTokenMetaTag.getAttribute('content'));
+	}
 
-	const ownerTypeInput = document.createElement('input');
-	ownerTypeInput.type = 'hidden';
-	ownerTypeInput.name = 'ownerType';
-	ownerTypeInput.value = requestBody.ownerType;
-
-	const archiveNameInput = document.createElement('input');
-	archiveNameInput.type = 'hidden';
-	archiveNameInput.name = 'archiveName';
-	archiveNameInput.value = requestBody.archiveName;
+	appendHiddenInput(form, 'ownerId', requestBody.ownerId);
+	appendHiddenInput(form, 'ownerType', requestBody.ownerType);
+	appendHiddenInput(form, 'archiveName', requestBody.archiveName);
 
 	if (selectedFileIds && selectedFileIds.length > 0) {
 		selectedFileIds.forEach((selectedFileId) => {
-			const selectedFilesInput = document.createElement('input');
-			selectedFilesInput.type = 'hidden';
-			selectedFilesInput.name = 'selectedFiles';
-			selectedFilesInput.value = selectedFileId;
-			form.appendChild(selectedFilesInput);
+			appendHiddenInput(form, 'selectedFiles', selectedFileId);
 		});
 	}
-
-	form.appendChild(ownerIdInput);
-	form.appendChild(ownerTypeInput);
-	form.appendChild(archiveNameInput);
 
 	document.body.appendChild(form);
 

--- a/static/scripts/teams.js
+++ b/static/scripts/teams.js
@@ -258,6 +258,19 @@ $(document).ready(() => {
 		updateFilesizeSum();
 	});
 
+	$(document).on('click', '.btn-filetree-toggle', (e) => {
+		e.preventDefault();
+		e.stopPropagation();
+
+		const $toggle = $(e.currentTarget);
+		const $children = $(document.getElementById($toggle.attr('aria-controls')));
+		const isExpanded = $toggle.attr('aria-expanded') === 'true';
+
+		$toggle.attr('aria-expanded', !isExpanded);
+		$toggle.find('i').toggleClass('fa-caret-right', isExpanded).toggleClass('fa-caret-down', !isExpanded);
+		$children.toggle(!isExpanded);
+	});
+
 	$('.btn-file-selective-download-submit').click(() => {
 		const selectedFileIds = getSelectedFileIds();
 		downloadFiles(selectedFileIds);

--- a/views/teams/partials/filetree.hbs
+++ b/views/teams/partials/filetree.hbs
@@ -14,6 +14,13 @@
             {{#each fileTree}}
                 {{#if this.isDirectory}}
                     <div class="filetree-folder" style="display: flex; gap: 10px;">
+                        {{#if this.children}}
+                            <button type="button" class="btn-filetree-toggle" aria-expanded="{{#if ../isSubFolder}}false{{else}}true{{/if}}" aria-controls="folder-children-{{this.id}}" aria-label="{{this.name}}" style="background: none; border: none; padding: 0; width: 1rem;">
+                                <i class="fa fa-caret-{{#if ../isSubFolder}}right{{else}}down{{/if}}" aria-hidden="true"></i>
+                            </button>
+                        {{else}}
+                            <span style="width: 1rem;"></span>
+                        {{/if}}
                         <span style="vertical-align: top; width: 1rem;">
                             <input type="checkbox" id="folder-{{this.id}}" class="folder-checkbox" data-file-id="{{this.id}}" data-file-name="{{this.name}}" data-file-size="{{this.size}}" data-file-parent-id="{{this.parentId}}">
                         </span>
@@ -23,12 +30,13 @@
                         </label>
                     </div>
                     {{#if this.children}}
-                        <div style="margin-left: 2rem; ">
+                        <div id="folder-children-{{this.id}}" class="filetree-children" style="margin-left: 2rem;{{#if ../isSubFolder}} display: none;{{/if}}">
                             {{#embed "teams/partials/filetree" fileTree=this.children teamFiles=true teamId=../_id isSubFolder=true}}{{/embed}}
                         </div>
                     {{/if}}
                 {{else}}
                     <div class="filetree-file" style="display: flex; gap: 10px">
+                        <span style="width: 1rem;"></span>
                         <span style="vertical-align: top; width: 1rem;">
                             <input type="checkbox" id="file-{{this.id}}" class="file-checkbox" data-file-id="{{this.id}}" data-file-name="{{this.name}}" data-file-size="{{this.size}}" data-file-parent-id="{{this.parentId}}">
                         </span>

--- a/views/teams/partials/filetree.hbs
+++ b/views/teams/partials/filetree.hbs
@@ -15,7 +15,7 @@
                 {{#if this.isDirectory}}
                     <div class="filetree-folder" style="display: flex; gap: 10px;">
                         {{#if this.children}}
-                            <button type="button" class="btn-filetree-toggle" aria-expanded="{{#if ../isSubFolder}}false{{else}}true{{/if}}" aria-controls="folder-children-{{this.id}}" aria-label="{{this.name}}" style="background: none; border: none; padding: 0; width: 1rem;">
+                            <button type="button" class="btn-filetree-toggle" aria-expanded="{{#if ../isSubFolder}}false{{else}}true{{/if}}" aria-controls="folder-children-{{this.id}}" aria-label="{{this.name}}" style="background: none; border: none; padding: 0; width: 1rem; height: 0.8rem;">
                                 <i class="fa fa-caret-{{#if ../isSubFolder}}right{{else}}down{{/if}}" aria-hidden="true"></i>
                             </button>
                         {{else}}

--- a/views/teams/partials/filetree.hbs
+++ b/views/teams/partials/filetree.hbs
@@ -15,7 +15,7 @@
                 {{#if this.isDirectory}}
                     <div class="filetree-folder" style="display: flex; gap: 10px;">
                         {{#if this.children}}
-                            <button type="button" class="btn-filetree-toggle" aria-expanded="{{#if ../isSubFolder}}false{{else}}true{{/if}}" aria-controls="folder-children-{{this.id}}" aria-label="{{this.name}}" style="background: none; border: none; padding: 0; width: 1rem; height: 0.8rem;">
+                            <button type="button" class="btn-filetree-toggle" aria-expanded="{{#if ../isSubFolder}}false{{else}}true{{/if}}" aria-controls="folder-children-{{this.id}}" aria-label="{{this.name}}" style="background: none; border: none; padding: 0; width: 1rem; height: 1.2rem;">
                                 <i class="fa fa-caret-{{#if ../isSubFolder}}right{{else}}down{{/if}}" aria-hidden="true"></i>
                             </button>
                         {{else}}


### PR DESCRIPTION
# Description
Fix to support very long lists of file-ids and complex structures of folders and sub-folders.

If very many files were selected in the download-filetree, it could happen, that the server returned a http-status 431 (="Request Header Fields Too Large") which resulted in authtication-token not being transmitted completely and authentication failing. 

Changes:
- switched download endpoint from GET to POST
- initially show folders in file-tree as collapsed and add toggle-button to unfold/fold the children
<img width="1033" height="394" alt="Filetree" src="https://github.com/user-attachments/assets/f223d3b6-6351-4b11-8940-6991d0c7e9f9" />

## Links to Tickets or other pull requests
SVSDEV-112
https://github.com/hpi-schul-cloud/schulcloud-server/pull/6454

## Approval for review

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.
